### PR TITLE
CI: self-hosted runner deployment workflow (issue #22)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy
+
+# Trigger: runs only after the CI workflow completes successfully on main.
+# Using workflow_run instead of a direct push trigger ensures that tests and
+# linting must pass before any deployment step executes.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types: [completed]
+
+# Secrets strategy: API keys are stored in config.json on the server and are
+# never managed by this workflow. The self-hosted runner has direct filesystem
+# access to the deploy directory, so no GitHub Actions secrets are needed for
+# application credentials. Keep config.json and profile.json in DEPLOY_DIR —
+# they are gitignored and will not be overwritten by git pull.
+
+jobs:
+  deploy:
+    name: Deploy to homelab server
+    runs-on: self-hosted
+
+    # Only proceed when the triggering CI run actually passed.
+    if: github.event.workflow_run.conclusion == 'success'
+
+    env:
+      DEPLOY_DIR: 'I:\Web Development\job_matcher'
+      SERVICE_NAME: JobMatcher
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Pull latest code
+        run: git -C "$env:DEPLOY_DIR" pull origin main
+
+      - name: Install dependencies
+        run: >
+          & (Join-Path $env:DEPLOY_DIR 'venv\Scripts\pip.exe') install -r
+          (Join-Path $env:DEPLOY_DIR 'requirements.txt')
+
+      - name: Restart service
+        run: nssm restart $env:SERVICE_NAME

--- a/README.md
+++ b/README.md
@@ -354,3 +354,32 @@ The SQLite database (`jobs.db`) is created there automatically on the first run.
 ### Note on Docker artifacts
 
 The `Dockerfile`, `docker-compose.yml`, and `.env.example` remain in the repo for portability. The native deployment uses system environment variables instead of `.env`.
+
+---
+
+## Automated deployment (self-hosted runner)
+
+Pushing to `main` triggers an automatic deployment on the homelab server via a self-hosted GitHub Actions runner.
+
+### Deployment flow
+
+```
+git push origin main
+        │
+        ▼
+GitHub Actions CI runs (tests + linting)
+        │ passes
+        ▼
+deploy.yml triggers on the self-hosted runner
+        │
+        ▼
+git pull → pip install → nssm restart JobMatcher
+```
+
+### One-time runner setup
+
+The self-hosted runner must be registered on the server before automated deployments will work. After running `scripts/setup.ps1`, follow the GitHub Actions runner setup steps documented at the bottom of that script. The steps cover downloading the runner, configuring it with the `self-hosted` label, and installing it as a Windows service so it persists across reboots.
+
+### Secrets and config
+
+`config.json` and `profile.json` are gitignored and are never touched by the workflow. API keys live only in `config.json` on the server — the deployment workflow does not use or require any GitHub Actions secrets for application credentials.

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -328,3 +328,32 @@ Write-Host "  4. Force ingest now:    $pythonExe ingest.py --hours 25"
 Write-Host ''
 Write-Host 'To remove everything cleanly, run: .\scripts\teardown.ps1' -ForegroundColor Yellow
 Write-Host ''
+
+# ===========================================================================
+# GITHUB ACTIONS SELF-HOSTED RUNNER SETUP (one-time, manual)
+# ===========================================================================
+# Complete these steps on this server after running this setup script,
+# to enable automatic deployment via GitHub Actions push-to-main.
+#
+# 1. Go to: https://github.com/cbeaulieu-gt/job-matcher-ui/settings/actions/runners
+#    Click "New self-hosted runner" -> select Windows -> follow the download
+#    and configure instructions.
+#
+# 2. When prompted for runner labels during configuration, add: self-hosted
+#    (the default). No additional labels are required.
+#
+# 3. Install the runner as a Windows service so it survives reboots:
+#       .\svc.ps1 install
+#       .\svc.ps1 start
+#
+# 4. Verify the runner service account (usually "SYSTEM" or a local admin)
+#    has permission to run `nssm restart JobMatcher`. Test with:
+#       nssm restart JobMatcher
+#    If it fails due to permissions, configure the runner service to run as
+#    a local administrator account via services.msc.
+#
+# 5. Confirm outbound HTTPS to github.com is not blocked by firewall/proxy.
+#
+# Once registered, pushing to main will automatically:
+#   git pull -> pip install -r requirements.txt -> nssm restart JobMatcher
+# ===========================================================================


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` — triggers via `workflow_run` after the `CI` workflow passes on `main`, ensuring a failing test or lint error never reaches the server
- On success, the self-hosted Windows runner: `git pull` → `pip install -r requirements.txt` → `nssm restart JobMatcher`
- API keys stay in `config.json` on the server — no GitHub Actions secrets needed (documented in a comment block in the workflow)
- Runner one-time setup instructions appended to `scripts/setup.ps1` and documented in `README.md`

## Deployment flow

```
git push origin main
        │
        ▼
GitHub Actions CI runs (tests + linting)
        │ passes
        ▼
deploy.yml triggers on the self-hosted runner
        │
        ▼
git pull → pip install → nssm restart JobMatcher
```

## Test plan

- [ ] Merge this PR to `main`
- [ ] Complete server setup prerequisites (see `scripts/setup.ps1` runner section): clone repo, register runner, install as Windows service
- [ ] Push a trivial commit to `main` and verify the deploy job appears in Actions and completes successfully
- [ ] Confirm `nssm status JobMatcher` shows `Running` after the deploy job finishes
- [ ] Push a commit that fails CI (e.g. a syntax error) and verify the deploy job does **not** trigger

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)