### PR TITLE
Fix: set DEPLOY_DIR to C:\Apps\job_matcher

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
 
     env:
-      DEPLOY_DIR: 'I:\Web Development\job_matcher'
+      DEPLOY_DIR: 'C:\Apps\job_matcher'
       SERVICE_NAME: JobMatcher
 
     defaults:


### PR DESCRIPTION
## Summary

- Updates `DEPLOY_DIR` in `deploy.yml` from `I:\Web Development\job_matcher` to `C:\Apps\job_matcher` to match the actual clone location on the homelab server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)