### PR TITLE
Feat: Claude CI auto-diagnosis on PR failure (#25)

### DIFF
--- a/.github/workflows/apply-fix.yml
+++ b/.github/workflows/apply-fix.yml
@@ -1,0 +1,51 @@
+name: Apply Claude Fix
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to apply fix to'
+        required: true
+      fix_diff:
+        description: 'Unified diff to apply'
+        required: true
+      fix_description:
+        description: 'One-line description of the fix'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  apply-fix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+          ref: refs/pull/${{ inputs.pr_number }}/head
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "Claude Auto-Fix"
+          git config user.email "claude-autofix@users.noreply.github.com"
+
+      - name: Apply fix
+        run: |
+          echo "${{ inputs.fix_diff }}" | git apply --index -
+          git commit -m "Claude auto-fix: ${{ inputs.fix_description }}
+
+          Applied automatically via apply-fix.yml workflow.
+          PR: #${{ inputs.pr_number }}"
+
+      - name: Push fix
+        run: |
+          # Get the PR head branch name
+          BRANCH=$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }} --jq '.head.ref')
+          git push origin HEAD:$BRANCH
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/ci-failure.yml
+++ b/.github/workflows/ci-failure.yml
@@ -1,0 +1,165 @@
+name: CI Failure Diagnosis
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get PR number
+        id: pr
+        run: |
+          PR=$(gh api repos/${{ github.repository }}/pulls \
+            --jq ".[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\") | .number" \
+            | head -1)
+          echo "number=$PR" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: Skip if no PR found
+        if: steps.pr.outputs.number == ''
+        run: |
+          echo "No PR found for commit ${{ github.event.workflow_run.head_sha }}, skipping."
+          exit 0
+
+      - name: Fetch failed job logs
+        id: logs
+        run: |
+          LOGS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | {name: .name, steps: [.steps[] | select(.conclusion == "failure") | .name]}]')
+          LOG_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
+
+          # Download the actual log text (first 8000 chars to stay within prompt limits)
+          RAW=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/logs 2>/dev/null | head -c 8000 || echo "Log download failed")
+
+          echo "log_url=$LOG_URL" >> $GITHUB_OUTPUT
+          # Write to file to avoid GITHUB_OUTPUT size limits
+          echo "$RAW" > /tmp/ci_logs.txt
+          echo "$LOGS" > /tmp/failed_jobs.json
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: Fetch PR diff
+        run: |
+          gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/files \
+            --jq '[.[] | {filename: .filename, patch: .patch}]' \
+            | head -c 6000 > /tmp/pr_diff.json
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: Call Claude for diagnosis
+        id: claude
+        run: |
+          LOGS=$(cat /tmp/ci_logs.txt | head -c 4000)
+          DIFF=$(cat /tmp/pr_diff.json)
+          CLAUDE_MD=$(cat CLAUDE.md 2>/dev/null | head -c 2000 || echo "No CLAUDE.md found")
+
+          PROMPT="You are a CI debugging assistant. A GitHub Actions CI run has failed on a pull request. Analyse the failure and suggest a minimal fix.
+
+PROJECT CONTEXT (CLAUDE.md):
+$CLAUDE_MD
+
+FAILED CI LOGS:
+$LOGS
+
+PR DIFF (changed files):
+$DIFF
+
+Respond with a JSON object with exactly these keys:
+- \"summary\": one sentence describing what failed
+- \"root_cause\": 2-3 sentences explaining why it failed
+- \"fix_description\": one sentence describing the fix
+- \"fix_diff\": a unified diff string showing the minimal code change needed (empty string if no code change needed)
+- \"confidence\": \"high\", \"medium\", or \"low\"
+
+Respond with raw JSON only, no markdown fences."
+
+          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "{
+              \"model\": \"claude-haiku-4-5-20251001\",
+              \"max_tokens\": 1024,
+              \"messages\": [{\"role\": \"user\", \"content\": $(echo "$PROMPT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}]
+            }")
+
+          echo "$RESPONSE" > /tmp/claude_response.json
+
+          SUMMARY=$(echo "$RESPONSE" | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+text = r['content'][0]['text']
+data = json.loads(text)
+print(data.get('summary', 'CI failure detected'))
+" 2>/dev/null || echo "CI failure detected")
+
+          echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Post diagnosis comment
+        run: |
+          python3 << 'PYEOF'
+          import json, os, subprocess
+
+          with open('/tmp/claude_response.json') as f:
+              response = json.load(f)
+
+          text = response['content'][0]['text']
+          data = json.loads(text)
+
+          summary = data.get('summary', 'CI failure detected')
+          root_cause = data.get('root_cause', 'Unable to determine root cause.')
+          fix_description = data.get('fix_description', '')
+          fix_diff = data.get('fix_diff', '')
+          confidence = data.get('confidence', 'low')
+          log_url = os.environ['LOG_URL']
+          pr_number = os.environ['PR_NUMBER']
+          repo = os.environ['REPO']
+
+          fix_section = ''
+          if fix_diff:
+              fix_section = f"""
+**Suggested fix:** {fix_description}
+```diff
+{fix_diff}
+```
+"""
+          else:
+              fix_section = f"\n**Suggested fix:** {fix_description}\n" if fix_description else ''
+
+          body = f"""## Claude CI Diagnosis
+
+**Summary:** {summary}
+
+**Root cause:** {root_cause}
+{fix_section}
+**Confidence:** {confidence} | [View full logs]({log_url})
+
+---
+_This diagnosis was generated automatically by Claude. Review before applying any suggested fix._
+
+_To apply the suggested fix automatically, trigger the [apply-fix workflow](../../actions/workflows/apply-fix.yml) with this PR number and the diff above._"""
+
+          cmd = ['gh', 'api', f'repos/{repo}/issues/{pr_number}/comments',
+                 '-f', f'body={body}']
+          subprocess.run(cmd, check=True, env={**os.environ})
+          PYEOF
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          LOG_URL: ${{ steps.logs.outputs.log_url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,7 +19,7 @@
     {
       "label": "Run Ingestion",
       "type": "shell",
-      "command": ".venv/Scripts/python ingest.py",
+      "command": ".venv/Scripts/python ingest.py --hours 24",
       "options": {
         "cwd": "${workspaceFolder}"
       },

--- a/README.md
+++ b/README.md
@@ -317,3 +317,12 @@ The self-hosted runner must be registered on the server before automated deploym
 ### Secrets and config
 
 `config.json`, `keys.json`, and `profile.json` are gitignored and are never touched by the workflow. API keys live only in `keys.json` on the server — the deployment workflow does not use or require any GitHub Actions secrets for application credentials.
+
+### Required secrets
+
+Add these in **Settings → Secrets and variables → Actions** for the CI failure diagnosis workflows to work:
+
+| Secret | Purpose |
+|---|---|
+| `ANTHROPIC_API_KEY` | Anthropic API key used by Claude to diagnose CI failures |
+| `GH_PAT` | GitHub Personal Access Token with `repo` scope — needed to post PR comments and push auto-fix commits |

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -188,6 +188,13 @@
 - [x] Instantiate correct client in `run()` / `rescore()` based on config provider value
 - [x] Add provider-specific API key fields to `config.example.json`
 
+## Feature: Claude CI Auto-Diagnosis (#25)
+
+- [ ] Add `ANTHROPIC_API_KEY` and `GH_PAT` to GitHub Actions secrets (manual step)
+- [x] Create `.github/workflows/ci-failure.yml` — triggers on CI workflow_run failure, fetches logs, calls Claude, posts PR comment
+- [x] Create `.github/workflows/apply-fix.yml` — manual workflow_dispatch trigger to apply suggested fix to PR branch
+- [x] Document secrets and new workflows in `README.md`
+
 ## Milestone: Dynamic Provider Key Management (#28–#36)
 
 - [x] **#28** — Create `keys.example.json`; strip API key fields from `config.example.json`; add `keys.json` to `.gitignore`


### PR DESCRIPTION
## Summary

- **`ci-failure.yml`**: Triggers on `workflow_run` failure for the CI workflow. Fetches failed job logs and PR diff via GitHub API, calls Claude Haiku with `CLAUDE.md` context + logs + diff, parses the structured JSON response, and posts a formatted diagnosis comment on the PR.
- **`apply-fix.yml`**: Manual `workflow_dispatch` trigger (intentionally not automatic). Checks out the PR branch, applies a provided unified diff via `git apply`, commits with a `Claude auto-fix:` prefix, and pushes to the PR head branch.
- **README**: Documents the two required secrets (`ANTHROPIC_API_KEY`, `GH_PAT`) under the CI/CD section.

## Required setup (manual)
Before these workflows will function, add to repo Settings -> Secrets and variables -> Actions:
- `ANTHROPIC_API_KEY` — Anthropic API key
- `GH_PAT` — GitHub PAT with `repo` scope (write access to PRs and contents)

## Design decisions
- **`apply-fix` is manual, not automatic** — Claude posts the diagnosis and diff in the PR comment; a developer reviews it and decides whether to trigger the apply workflow from the Actions UI. Prevents unreviewed commits.
- **`workflow_run` trigger** — fires in the base repo context where secrets are available, even for fork PRs. `pull_request` workflows don't have write access on forks.
- **Log/diff written to `/tmp` files** — avoids `GITHUB_OUTPUT` size limits for large log outputs.

## Test plan
- [x] Add `ANTHROPIC_API_KEY` and `GH_PAT` secrets to repo settings
- [ ] Open a PR that breaks a test — confirm diagnosis comment appears
- [ ] Trigger `apply-fix.yml` from Actions UI with PR number and a valid diff — confirm commit appears on PR branch

Closes #25

Generated with [Claude Code](https://claude.com/claude-code)