### PR TITLE
Fix: ci-failure workflow skips silently when no PR found

### DIFF
--- a/.github/workflows/ci-failure.yml
+++ b/.github/workflows/ci-failure.yml
@@ -28,13 +28,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
 
-      - name: Skip if no PR found
-        if: steps.pr.outputs.number == ''
-        run: |
-          echo "No PR found for commit ${{ github.event.workflow_run.head_sha }}, skipping."
-          exit 0
-
       - name: Fetch failed job logs
+        if: steps.pr.outputs.number != ''
         id: logs
         run: |
           LOGS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs \
@@ -52,6 +47,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Fetch PR diff
+        if: steps.pr.outputs.number != ''
         run: |
           gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/files \
             --jq '[.[] | {filename: .filename, patch: .patch}]' \
@@ -60,6 +56,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Call Claude for diagnosis
+        if: steps.pr.outputs.number != ''
         id: claude
         run: |
           # Build prompt via Python to avoid YAML indentation issues
@@ -118,6 +115,7 @@ print(data.get('summary', 'CI failure detected'))
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Post diagnosis comment
+        if: steps.pr.outputs.number != ''
         run: |
           python3 << 'PYEOF'
           import json, os, subprocess


### PR DESCRIPTION
## Summary

- `exit 0` in a GitHub Actions `run:` step means **success**, not stop — it does not halt the job. Steps after the "Skip if no PR found" step continued executing with `steps.pr.outputs.number` empty.
- "Fetch PR diff" then called `gh api .../pulls//files` (empty PR number in the URL), which returned a 404 and failed the step.
- Because "Fetch PR diff" failed, "Post diagnosis comment" never ran, so CI failures on commits without an open PR produced a broken workflow run rather than a clean skip.

## Fix

Removed the "Skip if no PR found" step entirely. Added `if: steps.pr.outputs.number != ''` to the four steps that depend on a PR being present:

- `Fetch failed job logs`
- `Fetch PR diff`
- `Call Claude for diagnosis`
- `Post diagnosis comment`

When no PR is found, GitHub Actions skips those steps cleanly and the workflow exits with success. The UI shows them as skipped rather than marking the run as failed.

Closes #45.

## Test plan

- [x] Trigger the CI failure workflow on a commit that has no open PR — confirm the four dependent steps are shown as skipped and the workflow exits green
- [x] Trigger it on a commit with an open PR — confirm all steps run and the diagnosis comment is posted as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)