### PR TITLE
Chore: remove credential prompts from setup.ps1, defer to UI (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,19 +220,20 @@ Use this approach if you want the web UI running as a Windows service and ingest
 
 What it does:
 
-- Prompts for your Adzuna credentials and the data directory path
-- Sets system environment variables (`DB_PATH`, `ADZUNA_APP_ID`, `ADZUNA_APP_KEY`, `FLASK_DEBUG`)
+- Prompts for the data directory path and daily ingest time (infrastructure only — no credential prompts)
+- Sets system environment variables (`DB_PATH`, `FLASK_DEBUG`)
 - Creates the data directory and a `logs/` subfolder
 - Copies `keys.example.json` → `keys.json` and restricts its ACL to the current user
+- Copies `config.example.json` → `config.json` (if absent) — edit it to add Adzuna credentials
 - Registers the `JobMatcher` Windows service (gunicorn via NSSM) set to auto-start
 - Registers the `JobMatcherIngest` daily Task Scheduler task
 
-After the script completes, start the service with `nssm start JobMatcher` and then navigate to `http://localhost:5000/settings` to enter your LLM provider API keys.
+After the script completes, navigate to `http://localhost:5000/settings` to enter your LLM provider API keys, then edit `config.json` in the project root to add your Adzuna App ID and App Key.
 
 ### Prerequisites
 
 - Python venv already set up and `pip install -r requirements.txt` run
-- `config.json` and `profile.json` present in the project root
+- `profile.json` present in the project root (`config.json` is created from the example by the script if absent)
 - [NSSM](https://nssm.cc/download) downloaded and either on `PATH` or referenced by full path
 
 ### Environment variables (reference)

--- a/app.py
+++ b/app.py
@@ -61,6 +61,30 @@ db.init_db(db_path=DB_PATH)
 
 
 # ---------------------------------------------------------------------------
+# Config warnings
+# ---------------------------------------------------------------------------
+
+def _config_warnings() -> list[str]:
+    """Return a list of human-readable warnings for missing/empty config."""
+    warnings = []
+    cfg = load_config()
+    adzuna_id  = cfg.get("adzuna_app_id", "").strip()
+    adzuna_key = cfg.get("adzuna_app_key", "").strip()
+    # Also check env vars (ingest.py can override via env)
+    if not adzuna_id:
+        adzuna_id = os.environ.get("ADZUNA_APP_ID", "").strip()
+    if not adzuna_key:
+        adzuna_key = os.environ.get("ADZUNA_APP_KEY", "").strip()
+    if not adzuna_id or not adzuna_key:
+        warnings.append(
+            "Adzuna credentials are not configured — ingest will not run. "
+            "Edit <code>config.json</code> in the project root to add your "
+            "<code>adzuna_app_id</code> and <code>adzuna_app_key</code>."
+        )
+    return warnings
+
+
+# ---------------------------------------------------------------------------
 # Template filter
 # ---------------------------------------------------------------------------
 
@@ -137,6 +161,7 @@ def feed():
         search=search,
         job_type=job_type,
         job_types=job_types,
+        config_warnings=_config_warnings(),
     )
 
 
@@ -148,6 +173,7 @@ def bookmarks():
         "index.html",
         listings=listings,
         view="bookmarks",
+        config_warnings=_config_warnings(),
     )
 
 
@@ -200,6 +226,7 @@ def applied():
         "index.html",
         listings=listings,
         view="applied",
+        config_warnings=_config_warnings(),
     )
 
 
@@ -207,7 +234,7 @@ def applied():
 def stats():
     """API usage and cost statistics."""
     data = db.get_usage_stats(db_path=DB_PATH)
-    return render_template("stats.html", stats=data, view="stats")
+    return render_template("stats.html", stats=data, view="stats", config_warnings=_config_warnings())
 
 
 @app.route("/dismiss/<int:listing_id>", methods=["POST"])

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -3,17 +3,15 @@
 .SYNOPSIS
     Interactive setup script for the Job Matcher native deployment.
 .DESCRIPTION
-    Registers the JobMatcher gunicorn service via NSSM and a daily ingest
-    scheduled task. Must be run as Administrator.
+    Provisions the JobMatcher infrastructure: registers the gunicorn service
+    via NSSM, creates a daily Task Scheduler ingest task, copies config/keys
+    example files on first run, and hardens file ACLs. Must be run as
+    Administrator.
 
-    Prompts for Adzuna credentials and data directory, sets system environment
-    variables (Machine scope), copies keys.json from the example template,
-    hardens its ACL to the current user, installs the NSSM service, and
-    registers the Windows Task Scheduler task.
-
-    LLM provider API keys (Anthropic, OpenAI, Gemini, etc.) are managed
-    through the /settings UI and stored in keys.json — they are NOT set as
-    environment variables by this script.
+    This script does NOT prompt for Adzuna credentials or LLM API keys.
+    After setup completes, open http://localhost:5000/settings to enter LLM
+    provider keys, then edit config.json in the project root to add your
+    Adzuna App ID and App Key before running ingest.
 .EXAMPLE
     .\setup.ps1
 .NOTES
@@ -128,7 +126,7 @@ if (-not $nssm) {
 Write-Ok "nssm found at: $($nssm.Source)"
 
 # ---------------------------------------------------------------------------
-# Step 3 - Prompt for configuration
+# Step 3 - Prompt for infrastructure configuration
 # ---------------------------------------------------------------------------
 Write-Host ''
 Write-Step 'Configuration prompts (press Enter to accept defaults)...'
@@ -137,18 +135,6 @@ Write-Host ''
 $dataDir = Read-Host -Prompt 'Data directory [C:\ProgramData\JobMatcher\data]'
 if ([string]::IsNullOrWhiteSpace($dataDir)) {
     $dataDir = 'C:\ProgramData\JobMatcher\data'
-}
-
-$adzunaAppId = Read-Host -Prompt 'Adzuna App ID'
-if ([string]::IsNullOrWhiteSpace($adzunaAppId)) {
-    Write-Error 'Adzuna App ID is required.'
-    exit 1
-}
-
-$adzunaAppKey = Read-Host -Prompt 'Adzuna App Key'
-if ([string]::IsNullOrWhiteSpace($adzunaAppKey)) {
-    Write-Error 'Adzuna App Key is required.'
-    exit 1
 }
 
 $ingestTime = Read-Host -Prompt 'Daily ingest time (24h HH:MM) [06:00]'
@@ -196,7 +182,27 @@ else {
 }
 
 # ---------------------------------------------------------------------------
-# Step 6 - Harden keys.json ACL
+# Step 6 - Set up config.json
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Step 'Setting up config.json...'
+
+$configPath        = Join-Path -Path $ProjectRoot -ChildPath 'config.json'
+$configExamplePath = Join-Path -Path $ProjectRoot -ChildPath 'config.example.json'
+
+if (-not (Test-Path -Path $configPath -PathType Leaf)) {
+    if (Test-Path -Path $configExamplePath -PathType Leaf) {
+        Copy-Item -Path $configExamplePath -Destination $configPath
+        Write-Ok 'config.json created from example — edit it at http://localhost:5000/settings or directly in the project root'
+    } else {
+        Write-Host '  config.example.json not found — skipping config.json creation.' -ForegroundColor Yellow
+    }
+} else {
+    Write-Ok 'config.json already present — skipping'
+}
+
+# ---------------------------------------------------------------------------
+# Step 7 - Harden keys.json ACL
 # ---------------------------------------------------------------------------
 Write-Host ''
 Write-Step 'Hardening keys.json permissions...'
@@ -219,7 +225,7 @@ else {
 }
 
 # ---------------------------------------------------------------------------
-# Step 7 - Set system environment variables
+# Step 8 - Set system environment variables
 # ---------------------------------------------------------------------------
 Write-Host ''
 Write-Step 'Setting system environment variables (Machine scope)...'
@@ -227,24 +233,17 @@ Write-Step 'Setting system environment variables (Machine scope)...'
 $dbPath = Join-Path -Path $dataDir -ChildPath 'jobs.db'
 
 $envVars = [ordered]@{
-    DB_PATH        = $dbPath
-    ADZUNA_APP_ID  = $adzunaAppId
-    ADZUNA_APP_KEY = $adzunaAppKey
-    FLASK_DEBUG    = '0'
+    DB_PATH     = $dbPath
+    FLASK_DEBUG = '0'
 }
 
 foreach ($key in $envVars.Keys) {
     [Environment]::SetEnvironmentVariable($key, $envVars[$key], 'Machine')
-    if ($key -eq 'ADZUNA_APP_KEY') {
-        Write-Ok "Set $key = $($envVars[$key].Substring(0, [Math]::Min(4, $envVars[$key].Length)))****"
-    }
-    else {
-        Write-Ok "Set $key = $($envVars[$key])"
-    }
+    Write-Ok "Set $key = $($envVars[$key])"
 }
 
 # ---------------------------------------------------------------------------
-# Step 8 - Register NSSM service
+# Step 9 - Register NSSM service
 # ---------------------------------------------------------------------------
 Write-Host ''
 Write-Step "Registering NSSM service: $ServiceName"
@@ -293,7 +292,7 @@ catch {
 }
 
 # ---------------------------------------------------------------------------
-# Step 9 - Register scheduled task
+# Step 10 - Register scheduled task
 # ---------------------------------------------------------------------------
 Write-Host ''
 Write-Step "Registering scheduled task: $TaskName"
@@ -353,16 +352,17 @@ catch {
 }
 
 # ---------------------------------------------------------------------------
-# Step 10 - Footer
+# Step 11 - Footer
 # ---------------------------------------------------------------------------
 Write-Host ''
 Write-Banner 'Setup Complete'
 Write-Host 'Next steps:' -ForegroundColor Cyan
-Write-Host "  1. Configure API keys:  http://localhost:5000/settings"
-Write-Host "  2. Open the feed:       http://localhost:5000"
-Write-Host "  3. Check status:        .\scripts\status.ps1"
-Write-Host "  4. View web logs:       $logsDir\web.log"
-Write-Host "  5. Force ingest now:    $pythonExe ingest.py --hours 25"
+Write-Host "  1. Open the app:        http://localhost:5000"
+Write-Host "  2. Configure LLM keys:  http://localhost:5000/settings"
+Write-Host "  3. Edit config.json:    $ProjectRoot\config.json  (Adzuna credentials, search params)"
+Write-Host "  4. Check status:        .\scripts\status.ps1"
+Write-Host "  5. View web logs:       $logsDir\web.log"
+Write-Host "  6. Force ingest now:    $pythonExe ingest.py --hours 25"
 Write-Host ''
 Write-Host 'To remove everything cleanly, run: .\scripts\teardown.ps1' -ForegroundColor Yellow
 Write-Host ''

--- a/static/style.css
+++ b/static/style.css
@@ -1103,3 +1103,23 @@ body {
   margin-bottom: 20px;
   max-width: 600px;
 }
+
+/* ------------------------------------------------------------
+   Setup banner
+   ------------------------------------------------------------ */
+.setup-banner {
+    background: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: #856404;
+}
+.setup-banner p {
+    margin: 0.25rem 0;
+}
+.setup-banner a {
+    color: #533f03;
+    font-weight: 600;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -48,6 +48,16 @@
     </div>
   {% endif %}
 
+  {# ── Setup banner ────────────────────────────────────────────── #}
+  {% if config_warnings %}
+  <div class="setup-banner">
+    {% for warning in config_warnings %}
+    <p>&#9888; {{ warning|safe }}</p>
+    {% endfor %}
+    <p>LLM provider keys can be configured on the <a href="/settings">Settings page</a>.</p>
+  </div>
+  {% endif %}
+
   {# ── Filter bar (feed only) ──────────────────────────────────── #}
   {% if view == "feed" %}
     <form class="filter-bar" method="get" action="/">

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -26,6 +26,16 @@
     </nav>
   </header>
 
+  {# ── Setup banner ────────────────────────────────────────────── #}
+  {% if config_warnings %}
+  <div class="setup-banner">
+    {% for warning in config_warnings %}
+    <p>&#9888; {{ warning|safe }}</p>
+    {% endfor %}
+    <p>LLM provider keys can be configured on the <a href="/settings">Settings page</a>.</p>
+  </div>
+  {% endif %}
+
   {# ── Summary stat boxes ──────────────────────────────────────── #}
   <div class="stats-summary">
     <div class="stat-box">


### PR DESCRIPTION
## Summary

- setup.ps1 no longer prompts for Adzuna App ID / App Key at install time — the Read-Host prompts and the ADZUNA_APP_ID/ADZUNA_APP_KEY system env var writes are removed
- setup.ps1 now copies config.example.json to config.json on first run (if absent), so users have a ready-to-edit file with the correct structure
- app.py gains a _config_warnings() helper that detects missing Adzuna credentials (checking both config.json and env vars) and returns human-readable warning strings; all main page routes (feed, bookmarks, applied, stats) pass this list to their templates
- templates/index.html and templates/stats.html render a yellow .setup-banner callout at the top of main whenever warnings are present, linking to /settings for LLM key setup
- static/style.css adds the .setup-banner rule set
- README.md native deployment section updated: Quick start bullet list and Prerequisites reflect the new no-credential-prompt flow

Closes #43

## Test plan

- All 148 existing pytest tests pass (verified locally)
- Run setup.ps1 and confirm it no longer prompts for Adzuna credentials
- With config.json absent or with empty adzuna_app_id/adzuna_app_key, load /, /bookmarks, /applied, /stats and confirm banner appears on each page
- With credentials present, confirm banner does not appear
- Confirm /settings link in banner is functional

Generated with Claude Code