### PR TITLE
Fix: replace gunicorn with waitress for Windows compatibility (#49)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Results include a `model_used` field stored as `"provider/model"` per listing. S
 ## Deployment
 
 **Windows native (active deployment path):**
-- `scripts/setup.ps1` — Registers gunicorn as an NSSM Windows service and creates a Task Scheduler job for daily ingest.
+- `scripts/setup.ps1` — Registers waitress as an NSSM Windows service and creates a Task Scheduler job for daily ingest.
 - `scripts/status.ps1` / `scripts/teardown.ps1` — Ops helpers.
 
 ## Key design decisions

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ What it does:
 - Creates the data directory and a `logs/` subfolder
 - Copies `keys.example.json` → `keys.json` and restricts its ACL to the current user
 - Copies `config.example.json` → `config.json` (if absent) — edit it to add Adzuna credentials
-- Registers the `JobMatcher` Windows service (gunicorn via NSSM) set to auto-start
+- Registers the `JobMatcher` Windows service (waitress via NSSM) set to auto-start
 - Registers the `JobMatcherIngest` daily Task Scheduler task
 
 After the script completes, navigate to `http://localhost:5000/settings` to enter your LLM provider API keys, then edit `config.json` in the project root to add your Adzuna App ID and App Key.
@@ -252,11 +252,11 @@ LLM provider API keys are managed separately through `keys.json` and the `/setti
 
 ### Web service — NSSM (reference)
 
-Register gunicorn as a Windows service named `JobMatcher`:
+Register waitress as a Windows service named `JobMatcher`:
 
 ```powershell
-nssm install JobMatcher "C:\Apps\job_matcher\venv\Scripts\gunicorn.exe"
-nssm set JobMatcher AppParameters "app:app --bind 0.0.0.0:5000 --workers 2"
+nssm install JobMatcher "C:\Apps\job_matcher\venv\Scripts\waitress-serve.exe"
+nssm set JobMatcher AppParameters "--host=0.0.0.0 --port=5000 app:app"
 nssm set JobMatcher AppDirectory "C:\Apps\job_matcher"
 nssm set JobMatcher Start SERVICE_AUTO_START
 nssm start JobMatcher

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ typing_extensions==4.15.0
 urllib3==2.6.3
 Werkzeug==3.1.7
 pytest==9.0.2
-gunicorn==23.0.0
+waitress==3.0.1

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -3,10 +3,10 @@
 .SYNOPSIS
     Interactive setup script for the Job Matcher native deployment.
 .DESCRIPTION
-    Provisions the JobMatcher infrastructure: registers the gunicorn service
-    via NSSM, creates a daily Task Scheduler ingest task, copies config/keys
-    example files on first run, and hardens file ACLs. Must be run as
-    Administrator.
+    Provisions the JobMatcher infrastructure: registers the waitress-serve
+    service via NSSM, creates a daily Task Scheduler ingest task, copies
+    config/keys example files on first run, and hardens file ACLs. Must be
+    run as Administrator.
 
     This script does NOT prompt for Adzuna credentials or LLM API keys.
     After setup completes, open http://localhost:5000/settings to enter LLM
@@ -16,7 +16,7 @@
     .\setup.ps1
 .NOTES
     Requires NSSM (https://nssm.cc/download) on PATH.
-    Requires gunicorn installed in the project venv before running.
+    Requires waitress installed in the project venv before running.
 #>
 
 [CmdletBinding(SupportsShouldProcess)]
@@ -99,10 +99,10 @@ catch {
     exit 1
 }
 
-# gunicorn.exe in venv
-$gunicornExe = Join-Path -Path $VenvScripts -ChildPath 'gunicorn.exe'
-if (-not (Test-Path -Path $gunicornExe -PathType Leaf)) {
-    Write-Fail "gunicorn.exe not found at: $gunicornExe"
+# waitress-serve.exe in venv
+$waitressExe = Join-Path -Path $VenvScripts -ChildPath 'waitress-serve.exe'
+if (-not (Test-Path -Path $waitressExe -PathType Leaf)) {
+    Write-Fail "waitress-serve.exe not found at: $waitressExe"
     Write-Host ''
     Write-Host 'Create and populate the venv before running setup:' -ForegroundColor Yellow
     Write-Host "  cd `"$ProjectRoot`""
@@ -111,7 +111,7 @@ if (-not (Test-Path -Path $gunicornExe -PathType Leaf)) {
     Write-Host ''
     exit 1
 }
-Write-Ok "gunicorn.exe found at: $gunicornExe"
+Write-Ok "waitress-serve.exe found at: $waitressExe"
 
 # NSSM on PATH
 $nssm = Get-Command -Name 'nssm' -ErrorAction SilentlyContinue
@@ -261,8 +261,8 @@ $webLog   = Join-Path -Path $logsDir -ChildPath 'web.log'
 $errorLog = Join-Path -Path $logsDir -ChildPath 'web-error.log'
 
 try {
-    & nssm install $ServiceName $gunicornExe
-    & nssm set $ServiceName AppParameters   "app:app --bind 0.0.0.0:5000 --workers 2"
+    & nssm install $ServiceName $waitressExe
+    & nssm set $ServiceName AppParameters   "--host=0.0.0.0 --port=5000 app:app"
     & nssm set $ServiceName AppDirectory    $ProjectRoot
     & nssm set $ServiceName Start           SERVICE_AUTO_START
     & nssm set $ServiceName AppStdout       $webLog

--- a/scripts/teardown.ps1
+++ b/scripts/teardown.ps1
@@ -3,7 +3,7 @@
 .SYNOPSIS
     Removes the Job Matcher NSSM service and Windows scheduled task.
 .DESCRIPTION
-    Stops and removes the JobMatcher gunicorn service registered by setup.ps1,
+    Stops and removes the JobMatcher waitress service registered by setup.ps1,
     and unregisters the JobMatcherIngest scheduled task.
 
     Optionally removes system environment variables. Does NOT delete the data


### PR DESCRIPTION
## Root cause

`gunicorn` imports `fcntl` at startup - a POSIX-only module that does not exist on Windows. The `JobMatcher` NSSM service registered by `scripts/setup.ps1` could never start on the native Windows deployment path because of this hard import failure.

## Fix

Replace gunicorn with **Waitress** (`waitress==3.0.1`), a pure-Python WSGI server with no OS-level dependencies. Waitress is the standard recommendation for serving WSGI apps on Windows.

The CLI flags differ between the two servers:
- gunicorn: `app:app --bind 0.0.0.0:5000 --workers 2`
- waitress: `--host=0.0.0.0 --port=5000 app:app`

## Files changed

| File | Change |
|---|---|
| `requirements.txt` | `gunicorn==23.0.0` removed, `waitress==3.0.1` added |
| `scripts/setup.ps1` | Prerequisite check and NSSM install updated to `waitress-serve.exe`; `AppParameters` updated to waitress CLI syntax; `.DESCRIPTION` and inline comments updated |
| `scripts/teardown.ps1` | `.DESCRIPTION` updated to reference waitress |
| `README.md` | Manual NSSM commands updated to `waitress-serve.exe` and new AppParameters; setup description updated |
| `CLAUDE.md` | Deployment section updated |

`.github/workflows/deploy.yml` and `scripts/status.ps1` needed no changes - both reference the service by name (`JobMatcher`), not by executable.

## Test plan

- [x] All 148 existing tests pass (`pytest tests/`)
- [ ] After deploying: confirm `pip install -r requirements.txt` installs `waitress-serve.exe` into `venv\Scripts\`
- [ ] After deploying: confirm `scripts/setup.ps1` runs cleanly and the `JobMatcher` service starts

Closes #49

Generated with [Claude Code](https://claude.com/claude-code)
