### PR TITLE
Fix: open Windows Firewall port 5000 in setup.ps1 (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ What it does:
 - Copies `config.example.json` → `config.json` (if absent) — edit it to add Adzuna credentials
 - Registers the `JobMatcher` Windows service (waitress via NSSM) set to auto-start
 - Registers the `JobMatcherIngest` daily Task Scheduler task
+- Opens Windows Firewall inbound TCP port 5000 so the UI is reachable from the network
 
 After the script completes, navigate to `http://localhost:5000/settings` to enter your LLM provider API keys, then edit `config.json` in the project root to add your Adzuna App ID and App Key.
 
@@ -260,6 +261,9 @@ nssm set JobMatcher AppParameters "--host=0.0.0.0 --port=5000 app:app"
 nssm set JobMatcher AppDirectory "C:\Apps\job_matcher"
 nssm set JobMatcher Start SERVICE_AUTO_START
 nssm start JobMatcher
+
+# Allow inbound connections from the network (run as Administrator)
+New-NetFirewallRule -DisplayName "Job Matcher Web UI" -Direction Inbound -Protocol TCP -LocalPort 5000 -Action Allow
 ```
 
 Service management:

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -352,7 +352,34 @@ catch {
 }
 
 # ---------------------------------------------------------------------------
-# Step 11 - Footer
+# Step 11 - Open Windows Firewall port 5000
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Step 'Opening Windows Firewall port 5000...'
+
+$fwRuleName = 'Job Matcher Web UI'
+$existingRule = Get-NetFirewallRule -DisplayName $fwRuleName -ErrorAction SilentlyContinue
+
+if ($existingRule) {
+    Write-Ok "Firewall rule '$fwRuleName' already exists — skipping"
+} else {
+    try {
+        New-NetFirewallRule `
+            -DisplayName $fwRuleName `
+            -Direction   Inbound `
+            -Protocol    TCP `
+            -LocalPort   5000 `
+            -Action      Allow | Out-Null
+        Write-Ok "Firewall rule added: allow inbound TCP 5000"
+    }
+    catch {
+        Write-Fail "Failed to add firewall rule: $_"
+        Write-Host '  Add it manually: New-NetFirewallRule -DisplayName "Job Matcher Web UI" -Direction Inbound -Protocol TCP -LocalPort 5000 -Action Allow' -ForegroundColor Yellow
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Step 12 - Footer
 # ---------------------------------------------------------------------------
 Write-Host ''
 Write-Banner 'Setup Complete'

--- a/scripts/teardown.ps1
+++ b/scripts/teardown.ps1
@@ -114,7 +114,15 @@ else {
 }
 
 # ---------------------------------------------------------------------------
-# Step 4 - Optionally remove environment variables
+# Step 4 - Remove Windows Firewall rule
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Step "Removing firewall rule: Job Matcher Web UI"
+Remove-NetFirewallRule -DisplayName 'Job Matcher Web UI' -ErrorAction SilentlyContinue
+Write-Ok 'Firewall rule removed (or was not present)'
+
+# ---------------------------------------------------------------------------
+# Step 5 - Optionally remove environment variables
 # ---------------------------------------------------------------------------
 Write-Host ''
 $removeEnv = Read-Host -Prompt 'Remove system environment variables (DB_PATH, API keys, FLASK_DEBUG)? [y/N]'
@@ -137,7 +145,7 @@ else {
 }
 
 # ---------------------------------------------------------------------------
-# Step 5 - Note about data directory
+# Step 6 - Note about data directory
 # ---------------------------------------------------------------------------
 Write-Host ''
 $dbPath = [Environment]::GetEnvironmentVariable('DB_PATH', 'Machine')


### PR DESCRIPTION
## Problem

`setup.ps1` did not add a Windows Firewall inbound rule for port 5000. Even though waitress binds to `0.0.0.0:5000`, Windows Firewall blocks inbound connections from other machines on the network by default, making the web UI unreachable from any host other than localhost.

## Changes

### `scripts/setup.ps1` (Step 11 — new)
Adds an idempotent firewall step between the NSSM service start and the footer:
- Checks whether the `Job Matcher Web UI` inbound rule already exists using `Get-NetFirewallRule`
- If absent, creates it with `New-NetFirewallRule` (TCP inbound, port 5000, allow)
- If already present, skips silently — safe to re-run setup without duplicate rules
- On failure, prints the manual command and continues rather than aborting setup

### `scripts/teardown.ps1` (Step 4 — new)
Removes the firewall rule with `Remove-NetFirewallRule -ErrorAction SilentlyContinue` so uninstall is clean regardless of whether the rule is present.

### `README.md`
- Added the `New-NetFirewallRule` command to the `### Web service — NSSM (reference)` manual steps section
- Added a bullet to the `### Quick start` list noting that the script opens port 5000 in Windows Firewall

Closes #51
