### PR TITLE
Fix: replace em dashes in setup.ps1 to resolve PS 5.1 parse error (#53)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,26 @@
 # Job Matcher — Implementation Plan
 
+## Bug: setup.ps1 parse error due to em dashes (#53)
+
+- [x] Replace all em dash characters (`—`) in `setup.ps1` with ASCII ` - ` (PS 5.1 misreads UTF-8 em dash bytes as a closing `"` under non-UTF8 system locale)
+- [x] Verify `ParseFile` reports 0 errors after fix
+
+## Bug: Open Windows Firewall port 5000 in setup.ps1 (#51)
+
+- [ ] Add inbound TCP allow rule for port 5000 to `setup.ps1` (idempotent — skip if rule already exists)
+- [ ] Add firewall rule removal to `teardown.ps1`
+- [ ] Update `README.md` native deployment section to mention the firewall rule
+
+## Bug: Replace gunicorn with Waitress (#49)
+
+- [ ] Swap `gunicorn` for `waitress` in `requirements.txt`
+- [ ] Update `scripts/setup.ps1` NSSM registration to invoke `waitress-serve` instead of `gunicorn.exe`
+- [ ] Update `scripts/status.ps1` — replace any gunicorn service/process references
+- [ ] Update `scripts/teardown.ps1` — replace any gunicorn references
+- [ ] Update `README.md` — replace gunicorn command examples with waitress-serve
+- [ ] Update `CLAUDE.md` — replace gunicorn references in deployment section
+- [ ] Check `.github/workflows/deploy.yml` for gunicorn references
+
 ## Phase 1: Foundation
 
 - [x] Create `requirements.txt` with `flask`, `requests`, `beautifulsoup4`, `anthropic`
@@ -187,6 +208,17 @@
 - [x] Implement Gemini adapter (gemini-1.5-flash / gemini-1.5-pro)
 - [x] Instantiate correct client in `run()` / `rescore()` based on config provider value
 - [x] Add provider-specific API key fields to `config.example.json`
+
+## Chore: Simplify setup.ps1 — defer config to Settings UI (#43)
+
+- [ ] Remove `Read-Host` prompts for `adzunaAppId` and `adzunaAppKey` from `setup.ps1`
+- [ ] Remove the `ADZUNA_APP_ID` / `ADZUNA_APP_KEY` system env var set step from `setup.ps1` (no longer prompted)
+- [ ] Keep `dataDir` and `ingestTime` prompts (infrastructure, not credentials)
+- [ ] Write skeleton `config.json` from `config.example.json` if absent (so app starts without crashing)
+- [ ] Keep skeleton `keys.json` copy from `keys.example.json` + ACL hardening (already present)
+- [ ] Add setup completion banner to `app.py` / `index.html` — warn when Adzuna credentials are missing from `config.json`, linking to `/settings` and instructions to edit `config.json`
+- [ ] Update `setup.ps1` footer and inline comments to reflect new flow: run script → open browser → finish config
+- [ ] Update `README.md` native deployment section to match new flow
 
 ## Feature: Claude CI Auto-Diagnosis (#25)
 

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -170,15 +170,15 @@ $keysExamplePath = Join-Path -Path $ProjectRoot -ChildPath 'keys.example.json'
 if (-not (Test-Path -Path $keysPath -PathType Leaf)) {
     if (Test-Path -Path $keysExamplePath -PathType Leaf) {
         Copy-Item -Path $keysExamplePath -Destination $keysPath
-        Write-Ok 'keys.json created from example — configure API keys at http://localhost:5000/settings'
+        Write-Ok 'keys.json created from example - configure API keys at http://localhost:5000/settings'
     }
     else {
-        Write-Host '  keys.example.json not found — skipping keys.json creation.' -ForegroundColor Yellow
+        Write-Host '  keys.example.json not found - skipping keys.json creation.' -ForegroundColor Yellow
         Write-Host '  Create keys.json manually in the project root before starting the service.' -ForegroundColor Yellow
     }
 }
 else {
-    Write-Ok 'keys.json already present — skipping'
+    Write-Ok 'keys.json already present - skipping'
 }
 
 # ---------------------------------------------------------------------------
@@ -193,12 +193,12 @@ $configExamplePath = Join-Path -Path $ProjectRoot -ChildPath 'config.example.jso
 if (-not (Test-Path -Path $configPath -PathType Leaf)) {
     if (Test-Path -Path $configExamplePath -PathType Leaf) {
         Copy-Item -Path $configExamplePath -Destination $configPath
-        Write-Ok 'config.json created from example — edit it at http://localhost:5000/settings or directly in the project root'
+        Write-Ok 'config.json created from example - edit it at http://localhost:5000/settings or directly in the project root'
     } else {
-        Write-Host '  config.example.json not found — skipping config.json creation.' -ForegroundColor Yellow
+        Write-Host '  config.example.json not found - skipping config.json creation.' -ForegroundColor Yellow
     }
 } else {
-    Write-Ok 'config.json already present — skipping'
+    Write-Ok 'config.json already present - skipping'
 }
 
 # ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@ if (Test-Path -Path $keysPath -PathType Leaf) {
     Write-Ok 'keys.json permissions restricted to current user'
 }
 else {
-    Write-Host '  keys.json not found — skipping ACL step.' -ForegroundColor Yellow
+    Write-Host '  keys.json not found - skipping ACL step.' -ForegroundColor Yellow
 }
 
 # ---------------------------------------------------------------------------
@@ -361,7 +361,7 @@ $fwRuleName = 'Job Matcher Web UI'
 $existingRule = Get-NetFirewallRule -DisplayName $fwRuleName -ErrorAction SilentlyContinue
 
 if ($existingRule) {
-    Write-Ok "Firewall rule '$fwRuleName' already exists — skipping"
+    Write-Ok "Firewall rule '$fwRuleName' already exists - skipping"
 } else {
     try {
         New-NetFirewallRule `


### PR DESCRIPTION
## Summary

- Replaced all 8 em dash characters (`—`, UTF-8 `E2 80 94`) in `scripts/setup.ps1` with ASCII ` - ` (space-hyphen-space)

## Root cause

PowerShell 5.1 on Windows systems with a non-UTF8 system locale (e.g. code page 1252) reads script files using the ANSI/OEM code page rather than UTF-8. The em dash is encoded as three bytes `E2 80 94` in UTF-8; when misread as Windows-1252, byte `0x94` maps to a right double quotation mark (`"`). This prematurely closes any open double-quoted string, desynchronising the parser and producing cascade errors at seemingly unrelated lines.

## Test plan

- [x] Verify `[System.Management.Automation.Language.Parser]::ParseFile` reports 0 errors on the updated file
- [x] Confirm script runs end-to-end on the server without parse exceptions

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)