### PR TITLE
Fix: grant SYSTEM FullControl on keys.json and config.json in setup.ps1 (#54)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,11 @@
 # Job Matcher — Implementation Plan
 
+## Bug: setup.ps1 ACL locks out SYSTEM service account (#54)
+
+- [x] In `setup.ps1` Step 7, add `NT AUTHORITY\SYSTEM` `FullControl` ACL entry on `keys.json` after the current-user rule
+- [x] Apply same SYSTEM grant to `config.json` in the same step
+- [x] Add explanatory comment in the ACL block
+
 ## Bug: setup.ps1 parse error due to em dashes (#53)
 
 - [x] Replace all em dash characters (`—`) in `setup.ps1` with ASCII ` - ` (PS 5.1 misreads UTF-8 em dash bytes as a closing `"` under non-UTF8 system locale)

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -202,26 +202,56 @@ if (-not (Test-Path -Path $configPath -PathType Leaf)) {
 }
 
 # ---------------------------------------------------------------------------
-# Step 7 - Harden keys.json ACL
+# Step 7 - Harden config file ACLs
 # ---------------------------------------------------------------------------
 Write-Host ''
-Write-Step 'Hardening keys.json permissions...'
+Write-Step 'Hardening config file permissions...'
 
-if (Test-Path -Path $keysPath -PathType Leaf) {
-    # Restrict keys.json to the current user only (removes inherited permissions)
-    $acl = Get-Acl $keysPath
-    $acl.SetAccessRuleProtection($true, $false)   # break inheritance, don't copy existing
+# Helper that applies a two-entry ACL to a file:
+#   - current interactive user: FullControl  (so the admin can edit files directly)
+#   - NT AUTHORITY\SYSTEM:      FullControl  (so the NSSM service can write via /settings)
+# Inheritance is broken so only these two explicit entries apply.
+function Set-ConfigFileAcl {
+    [CmdletBinding()]
+    param([string]$FilePath)
+
+    $acl = Get-Acl $FilePath
+    $acl.SetAccessRuleProtection($true, $false)   # break inheritance, don't copy existing rules
+
+    # Grant the admin who ran setup full control (direct file editing)
     $userRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
         [System.Security.Principal.WindowsIdentity]::GetCurrent().Name,
         'FullControl',
         'Allow'
     )
     $acl.SetAccessRule($userRule)
-    Set-Acl $keysPath $acl
-    Write-Ok 'keys.json permissions restricted to current user'
+
+    # Grant SYSTEM full control so the NSSM service process can write the file
+    # when Flask's /settings route saves updated keys/config
+    $systemRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        'NT AUTHORITY\SYSTEM',
+        'FullControl',
+        'Allow'
+    )
+    $acl.SetAccessRule($systemRule)
+
+    Set-Acl $FilePath $acl
+}
+
+if (Test-Path -Path $keysPath -PathType Leaf) {
+    Set-ConfigFileAcl -FilePath $keysPath
+    Write-Ok 'keys.json ACL: current user + SYSTEM = FullControl'
 }
 else {
     Write-Host '  keys.json not found - skipping ACL step.' -ForegroundColor Yellow
+}
+
+if (Test-Path -Path $configPath -PathType Leaf) {
+    Set-ConfigFileAcl -FilePath $configPath
+    Write-Ok 'config.json ACL: current user + SYSTEM = FullControl'
+}
+else {
+    Write-Host '  config.json not found - skipping ACL step.' -ForegroundColor Yellow
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extended `setup.ps1` Step 7 to grant `NT AUTHORITY\SYSTEM` `FullControl` on both `keys.json` and `config.json`
- Extracted the two-entry ACL logic into a `Set-ConfigFileAcl` helper to avoid duplication
- Added inline comments explaining why both accounts need access

## Root cause

Step 7 called `SetAccessRuleProtection($true, $false)` (break inheritance, don't copy existing rules) and then added only the interactive admin user as `FullControl`. The NSSM service runs as `NT AUTHORITY\SYSTEM`, which ended up with **no ACL entry at all** — so any write attempted by Flask's `/settings` route was rejected by the OS.

## What changed

`Set-ConfigFileAcl` now applies two explicit `Allow` entries:
| Account | Access |
|---|---|
| Current interactive user (admin who ran setup) | FullControl — for direct file editing |
| `NT AUTHORITY\SYSTEM` | FullControl — so the NSSM service can write via `/settings` |

## Test plan

- [ ] Run `setup.ps1` as Administrator; confirm both `keys.json` and `config.json` ACL messages appear
- [ ] Verify `/settings` can save keys without a permission error when the service is running as SYSTEM

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)