### PR TITLE
Feat: add Claude GitHub App workflow (#59)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,11 @@
+name: Claude Code
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  claude-response:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -220,6 +220,10 @@
 - [ ] Update `setup.ps1` footer and inline comments to reflect new flow: run script → open browser → finish config
 - [ ] Update `README.md` native deployment section to match new flow
 
+## Feature: Claude GitHub App workflow (#59)
+
+- [x] Create `.github/workflows/claude.yml` using `anthropics/claude-code-action@v1`, triggered on `issue_comment` (created)
+
 ## Feature: Claude CI Auto-Diagnosis (#25)
 
 - [ ] Add `ANTHROPIC_API_KEY` and `GH_PAT` to GitHub Actions secrets (manual step)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude.yml` using `anthropics/claude-code-action@v1`
- Triggered on `issue_comment` (created) events
- Allows `@claude` to be mentioned in any issue or PR comment to invoke Claude directly on the repository

## Prerequisites

- `ANTHROPIC_API_KEY` must be set as a repository secret (already present)
- Install the [Claude GitHub App](https://github.com/apps/claude) on this repository

## Test plan

- [x] Merge PR and install the Claude GitHub App on the repo
- [ ] Comment `@claude` on an issue to verify Claude responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)