### PR TITLE
Feat: add Claude GitHub App workflow (#59)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude.yml` using `anthropics/claude-code-action@v1`
- Triggered on `issue_comment` (created) events — allows `@claude` to be mentioned in any issue or PR comment
- Authenticates via `CLAUDE_CODE_OAUTH_TOKEN` (Claude GitHub App OAuth token)

## Prerequisites

- Install the [Claude GitHub App](https://github.com/apps/claude) on this repository
- Add `CLAUDE_CODE_OAUTH_TOKEN` as a repository secret (obtained during App installation)

## Test plan

- [ ] Merge PR and install the Claude GitHub App on the repo
- [ ] Comment `@claude` on an issue to verify Claude responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)