### PR TITLE
Feat: component version display on stats page (#6)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -195,9 +195,9 @@
 
 ## Feature: Component Version Display (#6)
 
-- [ ] Capture versions of key runtime components at startup (Python, Flask, anthropic, beautifulsoup4, gunicorn)
-- [ ] Expose version data via stats page or footer
-- [ ] Decide display location: stats page sidebar, footer, or dedicated info endpoint
+- [x] Capture versions of key runtime components at startup (Python, Flask, anthropic, beautifulsoup4, waitress)
+- [x] Expose version data via stats page — Runtime section with component/version table
+- [x] Decide display location: stats page (below per-day table and disclaimer)
 
 ## Feature: Last Fetch Time in UI (#7)
 

--- a/static/style.css
+++ b/static/style.css
@@ -984,6 +984,28 @@ body {
 }
 
 /* ------------------------------------------------------------
+   Stats page — runtime versions section
+   ------------------------------------------------------------ */
+.stats-section-heading {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  color: var(--text-muted);
+  font-weight: 600;
+  margin: 32px 0 12px;
+}
+
+.stats-runtime-table {
+  max-width: 360px;
+}
+
+.stats-runtime-table td.stats-version {
+  color: var(--text-accent);
+  font-family: var(--font-mono);
+}
+
+/* ------------------------------------------------------------
    Settings page
    ------------------------------------------------------------ */
 .settings-section-title {

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -94,6 +94,25 @@
     Actual charges may differ.
   </p>
 
+  {# ── Runtime versions ────────────────────────────────────────── #}
+  <h2 class="stats-section-heading">Runtime</h2>
+  <table class="stats-table stats-runtime-table">
+    <thead>
+      <tr>
+        <th>Component</th>
+        <th>Version</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in runtime_versions %}
+        <tr>
+          <td>{{ row.component }}</td>
+          <td class="stats-version">{{ row.version }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Added `get_runtime_versions()` helper in `app.py` — collects component versions once at startup and caches the result in `RUNTIME_VERSIONS` so the lookups don't repeat on every request
- Wired `runtime_versions` into the `/stats` route template context
- Added a **Runtime** section to `templates/stats.html` below the cost disclaimer, rendered as a table using the existing `stats-table` styles
- Added `.stats-section-heading` and `.stats-runtime-table` CSS classes to `static/style.css`

## Components surfaced

| Component | Source |
|---|---|
| App | `VERSION` file → `git describe --tags` → `"dev"` |
| Python | `sys.version_info` |
| Flask | `importlib.metadata.version("flask")` |
| anthropic | `importlib.metadata.version("anthropic")` |
| beautifulsoup4 | `importlib.metadata.version("beautifulsoup4")` |
| waitress | `importlib.metadata.version("waitress")` |

Each `importlib.metadata` call is wrapped in `try/except PackageNotFoundError` — a missing package surfaces as `"n/a"` instead of crashing the server.

Closes #6