### PR TITLE
Feat: display job posting date and sort by it (#40)

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,6 +177,21 @@ def salary_fmt(listing: dict) -> str | None:
     return f"{prefix}{fmt_k(hi)}"
 
 
+@app.template_filter("parse_iso")
+def parse_iso(value: str | None) -> datetime | None:
+    """Parse an ISO 8601 string (with or without trailing 'Z') into a datetime.
+
+    Returns None when ``value`` is None, empty, or cannot be parsed so that
+    downstream filters (e.g. ``timeago``) can handle the None case gracefully.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.rstrip("Z"))
+    except (ValueError, AttributeError):
+        return None
+
+
 @app.template_filter("timeago")
 def timeago(dt: datetime | None) -> str:
     """Return a human-readable relative time string for a datetime, e.g. '3 hours ago'.
@@ -245,6 +260,7 @@ def feed():
     remote_only = request.args.get("remote_only") == "1"
     search = request.args.get("search", "").strip() or None
     job_type = request.args.get("job_type", "").strip() or None
+    sort = request.args.get("sort", "").strip() or None
 
     listings = db.get_feed(
         threshold=threshold,
@@ -252,6 +268,7 @@ def feed():
         remote_only=remote_only,
         search=search,
         job_type=job_type,
+        sort=sort,
         db_path=DB_PATH,
     )
     job_types = db.get_job_types(db_path=DB_PATH)
@@ -266,6 +283,7 @@ def feed():
         search=search,
         job_type=job_type,
         job_types=job_types,
+        sort=sort,
         last_fetch_time=last_fetch_time,
         config_warnings=_config_warnings(),
     )

--- a/db.py
+++ b/db.py
@@ -95,6 +95,7 @@ def init_db(db_path: str = _DEFAULT_DB_PATH) -> None:
             ("model_used", "TEXT"),
             ("source", "TEXT"),
             ("source_id", "TEXT"),
+            ("posted_at", "TEXT"),
         ):
             try:
                 conn.execute(
@@ -190,6 +191,7 @@ def insert_listing(listing: dict, db_path: str = _DEFAULT_DB_PATH) -> None:
     row.setdefault("model_used", None)
     row.setdefault("source", None)
     row.setdefault("source_id", None)
+    row.setdefault("posted_at", None)
 
     conn = get_connection(db_path)
     try:
@@ -208,7 +210,8 @@ def insert_listing(listing: dict, db_path: str = _DEFAULT_DB_PATH) -> None:
                 job_type,
                 model_used,
                 source,
-                source_id
+                source_id,
+                posted_at
             ) VALUES (
                 :adzuna_id, :title, :company, :location,
                 :salary_min, :salary_max, :salary_is_predicted,
@@ -222,7 +225,8 @@ def insert_listing(listing: dict, db_path: str = _DEFAULT_DB_PATH) -> None:
                 :job_type,
                 :model_used,
                 :source,
-                :source_id
+                :source_id,
+                :posted_at
             )
             """,
             row,
@@ -315,9 +319,13 @@ def get_feed(
     remote_only: bool = False,
     search: str | None = None,
     job_type: str | None = None,
+    sort: str | None = None,
     db_path: str = _DEFAULT_DB_PATH,
 ) -> list[dict]:
-    """Return listings with score >= effective threshold and dismissed = 0, ordered by score DESC.
+    """Return listings with score >= effective threshold and dismissed = 0.
+
+    Default ordering is by score DESC. Pass ``sort='date_posted'`` to order by
+    ``posted_at DESC`` instead (newest listings first).
 
     Listings whose score is NULL are excluded (they have not been scored yet).
 
@@ -327,6 +335,8 @@ def get_feed(
         remote_only: If True, restricts to listings whose location contains "remote".
         search:      If provided, filters by title or company containing the search string.
         job_type:    If provided, restricts to listings whose job_type matches (case-insensitive).
+        sort:        Optional sort key. ``'date_posted'`` orders by posted_at DESC;
+                     any other value (or None) falls back to score DESC.
         db_path:     Path to the SQLite database file.
     """
     effective = min_score if min_score is not None else threshold
@@ -348,10 +358,15 @@ def get_feed(
 
     where_clause = " AND ".join(conditions)
 
+    if sort == "date_posted":
+        order_clause = "posted_at DESC"
+    else:
+        order_clause = "score DESC"
+
     conn = get_connection(db_path)
     try:
         rows = conn.execute(
-            f"SELECT * FROM listings WHERE {where_clause} ORDER BY score DESC",
+            f"SELECT * FROM listings WHERE {where_clause} ORDER BY {order_clause}",
             params,
         ).fetchall()
         return [_deserialise_row(r) for r in rows]

--- a/ingest.py
+++ b/ingest.py
@@ -354,6 +354,7 @@ class AdzunaClient:
             "description": raw.get("description", "") or "",
             "redirect_url": raw.get("redirect_url", "") or "",
             "created_at": raw.get("created", "") or "",
+            "posted_at": raw.get("created") or None,
         }
 
     def pages(self) -> Iterator[list[dict]]:

--- a/static/style.css
+++ b/static/style.css
@@ -394,6 +394,13 @@ body {
   border-left: 2px solid var(--border-mid);
 }
 
+/* Posted date — muted metadata line below the verdict */
+.posted-date {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin: 4px 0 10px;
+}
+
 /* Divider above actions */
 .card-divider {
   height: 1px;

--- a/templates/_card.html
+++ b/templates/_card.html
@@ -114,6 +114,16 @@
       <p class="verdict">{{ listing.verdict }}</p>
     {% endif %}
 
+    {# ── Posted date ─────────────────────────────────────────────── #}
+    <p class="posted-date">
+      {%- set posted_dt = listing.posted_at | parse_iso -%}
+      {%- if posted_dt is not none -%}
+        Posted {{ posted_dt | timeago }}
+      {%- else -%}
+        Posted: Unknown
+      {%- endif -%}
+    </p>
+
     {# ── Action row ──────────────────────────────────────────────── #}
     <div class="card-divider"></div>
     {% include "_actions.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,7 +34,7 @@
       <strong>{{ listings | length }}</strong>
       {%- if listings | length == 1 %} role{% else %} roles{% endif %}
       &nbsp;·&nbsp;
-      scored {{ (min_score if min_score is not none else threshold) | round(1) }}+ &nbsp;·&nbsp; sorted by match
+      scored {{ (min_score if min_score is not none else threshold) | round(1) }}+ &nbsp;·&nbsp; sorted by {% if sort == 'date_posted' %}date posted{% else %}match{% endif %}
       {%- if last_fetch_time is not none %}
         &nbsp;·&nbsp; <span class="last-fetch">last updated {{ last_fetch_time | timeago }}</span>
       {%- endif %}
@@ -76,6 +76,11 @@
         <option value="9" {% if min_score == 9.0 %}selected{% endif %}>9+</option>
       </select>
 
+      <select name="sort" class="filter-select">
+        <option value="" {% if not sort %}selected{% endif %}>Sort: score</option>
+        <option value="date_posted" {% if sort == 'date_posted' %}selected{% endif %}>Sort: date posted</option>
+      </select>
+
       {% if job_types %}
       <select name="job_type" class="filter-select">
         <option value="">Role: all</option>
@@ -95,7 +100,7 @@
       </label>
 
       <button type="submit" class="btn filter-btn">Filter</button>
-      {% if search or min_score or remote_only or job_type %}
+      {% if search or min_score or remote_only or job_type or sort %}
         <a href="/" class="filter-clear">Clear</a>
       {% endif %}
     </form>

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -45,6 +45,7 @@ def make_listing(
     model_used: str | None = None,
     source: str = "adzuna",
     source_id: str | None = None,
+    posted_at: str | None = None,
 ) -> dict:
     """Return a complete listing dict suitable for db.insert_listing().
 
@@ -78,6 +79,7 @@ def make_listing(
         "applied": applied,
         "job_type": job_type,
         "model_used": model_used,
+        "posted_at": posted_at,
     }
 
 
@@ -782,3 +784,142 @@ class TestGetLastFetchTime:
             assert isinstance(result, datetime.datetime)
             assert result.year == 2026
             assert result.month == 6
+
+
+# ---------------------------------------------------------------------------
+# posted_at column — migration, storage, and sort
+# ---------------------------------------------------------------------------
+
+class TestPostedAt:
+    def test_column_exists_in_schema(self):
+        """init_db() creates the posted_at column (verifiable via PRAGMA)."""
+        with TempDB() as path:
+            conn = db.get_connection(path)
+            try:
+                cols = conn.execute("PRAGMA table_info(listings)").fetchall()
+                col_names = [c["name"] for c in cols]
+                assert "posted_at" in col_names
+            finally:
+                conn.close()
+
+    def test_posted_at_stored_and_retrieved(self):
+        """posted_at set on insert is present in the row returned by get_feed()."""
+        with TempDB() as path:
+            db.insert_listing(
+                make_listing(adzuna_id="pa-001", score=8.0, posted_at="2026-03-01T09:00:00Z"),
+                db_path=path,
+            )
+            feed = db.get_feed(threshold=7.0, db_path=path)
+            row = next(r for r in feed if r["adzuna_id"] == "pa-001")
+            assert row["posted_at"] == "2026-03-01T09:00:00Z"
+
+    def test_posted_at_null_when_not_supplied(self):
+        """When posted_at is not in the listing dict, it is stored as NULL."""
+        with TempDB() as path:
+            listing = make_listing(adzuna_id="pa-002", score=8.0)
+            # Ensure the key is absent (not just None) to test the setdefault path.
+            listing.pop("posted_at", None)
+            db.insert_listing(listing, db_path=path)
+            conn = db.get_connection(path)
+            try:
+                row = conn.execute(
+                    "SELECT posted_at FROM listings WHERE adzuna_id = 'pa-002'"
+                ).fetchone()
+                assert row["posted_at"] is None
+            finally:
+                conn.close()
+
+    def test_sort_date_posted_orders_newest_first(self):
+        """get_feed(sort='date_posted') returns listings ordered by posted_at DESC."""
+        with TempDB() as path:
+            db.insert_listing(
+                make_listing(adzuna_id="pa-old", score=9.0, posted_at="2026-01-01T00:00:00Z"),
+                db_path=path,
+            )
+            db.insert_listing(
+                make_listing(adzuna_id="pa-new", score=7.0, source_id="pa-new",
+                             posted_at="2026-03-20T00:00:00Z"),
+                db_path=path,
+            )
+            db.insert_listing(
+                make_listing(adzuna_id="pa-mid", score=8.0, source_id="pa-mid",
+                             posted_at="2026-02-15T00:00:00Z"),
+                db_path=path,
+            )
+            results = db.get_feed(threshold=7.0, sort="date_posted", db_path=path)
+            ids = [r["adzuna_id"] for r in results]
+            assert ids == ["pa-new", "pa-mid", "pa-old"]
+
+    def test_sort_default_still_orders_by_score(self):
+        """get_feed() without sort param still orders by score DESC."""
+        with TempDB() as path:
+            db.insert_listing(
+                make_listing(adzuna_id="sc-low", score=7.5, posted_at="2026-03-25T00:00:00Z"),
+                db_path=path,
+            )
+            db.insert_listing(
+                make_listing(adzuna_id="sc-high", score=9.5, source_id="sc-high",
+                             posted_at="2026-01-01T00:00:00Z"),
+                db_path=path,
+            )
+            results = db.get_feed(threshold=7.0, db_path=path)
+            ids = [r["adzuna_id"] for r in results]
+            # sc-high has the higher score so should appear first despite older posted_at
+            assert ids[0] == "sc-high"
+
+    def test_migration_adds_posted_at_to_existing_db(self):
+        """init_db() adds posted_at to a database that was created without it."""
+        with TempDB() as path:
+            # Simulate a pre-migration database by dropping the column via table rename.
+            conn = db.get_connection(path)
+            try:
+                conn.execute("ALTER TABLE listings RENAME TO listings_old")
+                conn.execute("""
+                    CREATE TABLE listings (
+                        id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                        adzuna_id TEXT UNIQUE NOT NULL,
+                        title     TEXT,
+                        score     REAL,
+                        seen      INTEGER DEFAULT 0
+                    )
+                """)
+                conn.execute(
+                    "INSERT INTO listings (adzuna_id, title, score, seen) "
+                    "SELECT adzuna_id, title, score, seen FROM listings_old"
+                )
+                conn.execute("DROP TABLE listings_old")
+                conn.commit()
+            finally:
+                conn.close()
+
+            db.init_db(path)
+
+            conn = db.get_connection(path)
+            try:
+                cols = conn.execute("PRAGMA table_info(listings)").fetchall()
+                col_names = [c["name"] for c in cols]
+                assert "posted_at" in col_names
+            finally:
+                conn.close()
+
+    def test_null_posted_at_does_not_crash_sort(self):
+        """get_feed(sort='date_posted') works even when some rows have NULL posted_at.
+
+        SQLite sorts NULLs before non-NULL values in ASC order (i.e. last in DESC).
+        The important thing is no exception is raised and non-NULL rows sort first.
+        """
+        with TempDB() as path:
+            db.insert_listing(
+                make_listing(adzuna_id="null-pa", score=8.0, posted_at=None),
+                db_path=path,
+            )
+            db.insert_listing(
+                make_listing(adzuna_id="real-pa", score=7.5, source_id="real-pa",
+                             posted_at="2026-03-01T00:00:00Z"),
+                db_path=path,
+            )
+            results = db.get_feed(threshold=7.0, sort="date_posted", db_path=path)
+            ids = [r["adzuna_id"] for r in results]
+            # real-pa has a non-NULL posted_at so should sort first (DESC puts NULLs last)
+            assert ids[0] == "real-pa"
+            assert "null-pa" in ids


### PR DESCRIPTION
## Summary
- Stores Adzuna `created` field as `posted_at` in DB via migration
- Renders "Posted N days ago" on each listing card
- Adds "Date Posted" sort option to feed filter bar

## Test plan
- [ ] `pytest` passes — new DB migration and sort tests included
- [ ] Cards show "Posted N days ago" for new listings, "Unknown" for old ones
- [ ] "Date Posted" sort orders feed newest-first

🤖 Generated with Claude Code