### PR TITLE
Fix: migrate Google provider from google.generativeai to google.genai (#39)

### DIFF
--- a/providers/gemini_provider.py
+++ b/providers/gemini_provider.py
@@ -1,7 +1,7 @@
 """
 providers/gemini_provider.py — Google Gemini backend for LLM scoring.
 
-Wraps the ``google-generativeai`` SDK.  Uses the same JSON contract and
+Wraps the ``google-genai`` SDK.  Uses the same JSON contract and
 retry pattern as the other providers so that ``score_listing()`` in
 ``ingest.py`` is provider-agnostic.
 """
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import time
 
-import google.generativeai as genai
+from google import genai
 
 from .base import LLMProvider
 from .anthropic_provider import _parse_json_response
@@ -61,7 +61,7 @@ class GeminiProvider(LLMProvider):
     """
 
     def __init__(self, api_key: str, model: str) -> None:
-        genai.configure(api_key=api_key)
+        self._client = genai.Client(api_key=api_key)
         self._model_name = model
         self._input_cost, self._output_cost = _pricing_for_model(model)
 
@@ -101,8 +101,10 @@ class GeminiProvider(LLMProvider):
                 time.sleep(2)
 
             try:
-                model = genai.GenerativeModel(self._model_name)
-                response = model.generate_content(prompt)
+                response = self._client.models.generate_content(
+                    model=self._model_name,
+                    contents=prompt,
+                )
             except Exception as exc:  # noqa: BLE001 — Gemini raises varied errors
                 logger.warning(
                     "Gemini API error (attempt %d/2): %s", attempt + 1, exc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.7.0
 anthropic==0.86.0
 openai>=1.0.0
-google-generativeai>=0.8.0
+google-genai>=0.8.0
 anyio==4.13.0
 beautifulsoup4==4.14.3
 blinker==1.9.0

--- a/tests/test_provider_chain.py
+++ b/tests/test_provider_chain.py
@@ -51,8 +51,7 @@ def _make_keys(
 _PATCHES = [
     patch("providers.anthropic_provider.anthropic.Anthropic"),
     patch("providers.openai_provider.openai.OpenAI"),
-    patch("providers.gemini_provider.genai.configure"),
-    patch("providers.gemini_provider.genai.GenerativeModel"),
+    patch("providers.gemini_provider.genai.Client"),
 ]
 
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -355,11 +355,10 @@ class TestOpenAIProvider:
 # ---------------------------------------------------------------------------
 
 class TestGeminiProvider:
-    """Tests for GeminiProvider.complete() — google.generativeai SDK is mocked."""
+    """Tests for GeminiProvider.complete() — google.genai SDK is mocked."""
 
     def _make_provider(self) -> GeminiProvider:
-        with patch("providers.gemini_provider.genai.configure"), \
-             patch("providers.gemini_provider.genai.GenerativeModel"):
+        with patch("providers.gemini_provider.genai.Client"):
             return GeminiProvider(api_key="test-key", model="gemini-1.5-flash")
 
     def test_happy_path_returns_parsed_dict(self):
@@ -367,9 +366,8 @@ class TestGeminiProvider:
         provider = self._make_provider()
         fake_resp = _make_gemini_response(json.dumps(_VALID_SCORE_DICT))
 
-        with patch("providers.gemini_provider.genai.GenerativeModel") as MockModel:
-            MockModel.return_value.generate_content.return_value = fake_resp
-            result = provider.complete("test prompt")
+        provider._client.models.generate_content.return_value = fake_resp
+        result = provider.complete("test prompt")
 
         assert result["score"] == 8
         assert result["tokens_input"] == 100
@@ -381,9 +379,8 @@ class TestGeminiProvider:
         fenced = f"```json\n{json.dumps(_VALID_SCORE_DICT)}\n```"
         fake_resp = _make_gemini_response(fenced)
 
-        with patch("providers.gemini_provider.genai.GenerativeModel") as MockModel:
-            MockModel.return_value.generate_content.return_value = fake_resp
-            result = provider.complete("test prompt")
+        provider._client.models.generate_content.return_value = fake_resp
+        result = provider.complete("test prompt")
 
         assert result["score"] == 8
 
@@ -392,9 +389,8 @@ class TestGeminiProvider:
         provider = self._make_provider()
         fake_resp = _make_gemini_response(json.dumps(_VALID_SCORE_DICT))
 
-        with patch("providers.gemini_provider.genai.GenerativeModel") as MockModel, \
-             patch("providers.gemini_provider.time.sleep"):
-            MockModel.return_value.generate_content.side_effect = [
+        with patch("providers.gemini_provider.time.sleep"):
+            provider._client.models.generate_content.side_effect = [
                 RuntimeError("connection reset"),
                 fake_resp,
             ]
@@ -406,9 +402,8 @@ class TestGeminiProvider:
         """complete() raises RuntimeError after two consecutive failures."""
         provider = self._make_provider()
 
-        with patch("providers.gemini_provider.genai.GenerativeModel") as MockModel, \
-             patch("providers.gemini_provider.time.sleep"):
-            MockModel.return_value.generate_content.side_effect = RuntimeError("quota exceeded")
+        with patch("providers.gemini_provider.time.sleep"):
+            provider._client.models.generate_content.side_effect = RuntimeError("quota exceeded")
             with pytest.raises(RuntimeError, match="2 attempts"):
                 provider.complete("test prompt")
 
@@ -456,8 +451,7 @@ class TestMakeProvider:
     def test_gemini_provider_selected(self):
         """make_provider() returns GeminiProvider when provider='gemini'."""
         config = self._base_config("gemini", "gemini-1.5-flash")
-        with patch("providers.gemini_provider.genai.configure"), \
-             patch("providers.gemini_provider.genai.GenerativeModel"):
+        with patch("providers.gemini_provider.genai.Client"):
             provider = make_provider(config)
         assert isinstance(provider, GeminiProvider)
 
@@ -504,7 +498,6 @@ class TestMakeProvider:
             "scoring": {"provider": "gemini", "model": "gemini-1.5-flash"},
         }
         with patch.dict(os.environ, {"GOOGLE_API_KEY": "google-env-key"}), \
-             patch("providers.gemini_provider.genai.configure") as mock_configure, \
-             patch("providers.gemini_provider.genai.GenerativeModel"):
+             patch("providers.gemini_provider.genai.Client") as mock_client:
             make_provider(config)
-        mock_configure.assert_called_once_with(api_key="google-env-key")
+        mock_client.assert_called_once_with(api_key="google-env-key")


### PR DESCRIPTION
## Summary
- Replaces deprecated `google-generativeai` with `google-genai` SDK
- Updates client instantiation, model call, and response parsing for new API surface
- Auth and model-not-found error handling preserved

## Test plan
- [ ] All existing tests pass (`pytest`)
- [ ] No regressions in Anthropic or OpenAI provider tests

🤖 Generated with Claude Code