### PR TITLE
Feat: edit config.json via web UI (#21)

### DIFF
--- a/app.py
+++ b/app.py
@@ -361,6 +361,36 @@ def dismiss(listing_id: int):
     return make_response("", 200)
 
 
+def _mask_config_keys(data: dict) -> dict:
+    """Return a deep copy of *data* with sensitive key values replaced by '***'.
+
+    Any key whose name (lowercased) ends in ``_api_key``, ``_app_key``, or
+    ``_app_id`` is considered sensitive.  The walk is recursive so nested dicts
+    (e.g. ``search`` or ``prefilter`` sub-objects) are handled too.
+
+    The original dict is never mutated — callers always receive a fresh copy.
+    This is display-only: the masked value is never written back to disk.
+    """
+    import copy
+
+    _SENSITIVE_SUFFIXES = ("_api_key", "_app_key", "_app_id")
+
+    def _walk(obj):
+        if isinstance(obj, dict):
+            result = {}
+            for k, v in obj.items():
+                if isinstance(k, str) and k.lower().endswith(_SENSITIVE_SUFFIXES):
+                    result[k] = "***"
+                else:
+                    result[k] = _walk(v)
+            return result
+        if isinstance(obj, list):
+            return [_walk(item) for item in obj]
+        return copy.deepcopy(obj)
+
+    return _walk(data)
+
+
 def _load_keys() -> dict:
     """Load keys.json if it exists, otherwise return a copy of the defaults.
 
@@ -472,6 +502,83 @@ def settings():
         has_adzuna_id=has_adzuna_id,
         has_adzuna_key=has_adzuna_key,
     )
+
+
+@app.route("/settings/config", methods=["GET", "POST"])
+def settings_config():
+    """Config editor page — view and edit config.json via the browser.
+
+    GET:  Reads config.json, masks any sensitive key fields (``*_api_key``,
+          ``*_app_key``, ``*_app_id``), pretty-prints the result as JSON, and
+          renders it in a ``<textarea>`` for editing.
+
+    POST: Validates the submitted JSON. If parsing fails, returns a 400 with an
+          inline error and leaves config.json untouched. If the JSON is valid,
+          overwrites config.json and shows a success notice. Masked values
+          (``"***"``) are never written back to disk — if the submitted JSON
+          still contains ``"***"`` for a sensitive field, the original value
+          from the current config is preserved.
+    """
+    saved = False
+    error = None
+    status_code = 200
+
+    if request.method == "POST":
+        raw = request.form.get("config_json", "")
+        try:
+            submitted = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            error = f"Invalid JSON: {exc}"
+            status_code = 400
+            submitted = None
+
+        if submitted is not None:
+            # Merge: if a sensitive field still holds the masked sentinel,
+            # preserve the original value so we never overwrite with "***".
+            existing = load_config(_CONFIG_PATH)
+            _SENSITIVE_SUFFIXES = ("_api_key", "_app_key", "_app_id")
+
+            def _restore_masked(new_obj, orig_obj):
+                """Recursively replace '***' sentinel values with originals."""
+                if not isinstance(new_obj, dict):
+                    return new_obj
+                result = {}
+                for k, v in new_obj.items():
+                    if (
+                        isinstance(k, str)
+                        and k.lower().endswith(_SENSITIVE_SUFFIXES)
+                        and v == "***"
+                        and isinstance(orig_obj, dict)
+                        and k in orig_obj
+                    ):
+                        result[k] = orig_obj[k]
+                    elif isinstance(v, dict):
+                        result[k] = _restore_masked(v, orig_obj.get(k, {}) if isinstance(orig_obj, dict) else {})
+                    else:
+                        result[k] = v
+                return result
+
+            to_write = _restore_masked(submitted, existing)
+
+            try:
+                with open(_CONFIG_PATH, "w", encoding="utf-8") as f:
+                    json.dump(to_write, f, indent=2)
+                saved = True
+            except OSError:
+                error = "Could not save config — check file permissions."
+
+    # Always re-read from disk (after write or on GET) for the textarea.
+    cfg_display = load_config(_CONFIG_PATH)
+    masked = _mask_config_keys(cfg_display)
+    config_json_str = json.dumps(masked, indent=2)
+
+    return render_template(
+        "settings_config.html",
+        view="settings",
+        config_json=config_json_str,
+        saved=saved,
+        error=error,
+    ), status_code
 
 
 # ---------------------------------------------------------------------------

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -177,6 +177,14 @@
 
   </form>
 
+  {# ── Advanced config link ─────────────────────────────────── #}
+  <div style="margin-top: 32px; max-width: 600px;">
+    <h2 class="settings-section-title">Advanced</h2>
+    <p class="settings-label">
+      <a href="/settings/config">Edit config.json directly</a> — search params, scoring threshold, prefilter rules.
+    </p>
+  </div>
+
 </div>
 </body>
 </html>

--- a/templates/settings_config.html
+++ b/templates/settings_config.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Job Matcher · Config Editor</title>
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="page-wrap">
+
+  {# ── Header ─────────────────────────────────────────────────── #}
+  <header class="site-header">
+    <span class="site-logo">job<span>_</span>matcher</span>
+    <nav class="site-nav">
+      <a href="/"
+         class="nav-tab{% if view == 'feed' %} active{% endif %}">feed</a>
+      <a href="/bookmarks"
+         class="nav-tab{% if view == 'bookmarks' %} active{% endif %}">bookmarks</a>
+      <a href="/applied"
+         class="nav-tab{% if view == 'applied' %} active{% endif %}">applied</a>
+      <a href="/stats"
+         class="nav-tab{% if view == 'stats' %} active{% endif %}">stats</a>
+      <a href="/settings"
+         class="nav-tab{% if view == 'settings' %} active{% endif %}">settings</a>
+    </nav>
+  </header>
+
+  {# ── Breadcrumb ────────────────────────────────────────────── #}
+  <div class="feed-meta">
+    <a href="/settings">Settings</a> &rsaquo; Config Editor
+  </div>
+
+  {# ── Success notice ───────────────────────────────────────────── #}
+  {% if saved %}
+    <p class="save-notice">config.json saved.</p>
+  {% endif %}
+
+  {# ── Error notice ─────────────────────────────────────────────── #}
+  {% if error %}
+    <p class="save-error">{{ error }}</p>
+  {% endif %}
+
+  {# ── Editor form ──────────────────────────────────────────────── #}
+  <form class="settings-form" method="post" action="/settings/config">
+
+    <h2 class="settings-section-title">config.json</h2>
+
+    <p class="settings-label">
+      Edit the raw JSON below. Sensitive fields (app IDs, app keys, API keys) are
+      shown as <code>***</code> and will not be overwritten if left unchanged.
+    </p>
+
+    <textarea
+      id="config_json"
+      name="config_json"
+      class="settings-input"
+      rows="30"
+      spellcheck="false"
+      autocomplete="off"
+      style="font-family: var(--font-mono); resize: vertical; white-space: pre;">{{ config_json }}</textarea>
+
+    <button type="submit" class="btn btn-save">Save</button>
+
+  </form>
+
+</div>
+</body>
+</html>

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -387,6 +387,197 @@ class TestSettingsAdzuna:
 
 
 # ---------------------------------------------------------------------------
+# GET /settings/config (#21)
+# ---------------------------------------------------------------------------
+
+class TestSettingsConfigGet:
+    """Tests for the GET /settings/config route."""
+
+    def test_returns_200(self, client, tmp_config_path):
+        resp = client.get("/settings/config")
+        assert resp.status_code == 200
+
+    def test_renders_textarea_with_json(self, client, tmp_config_path):
+        with open(tmp_config_path, "w") as f:
+            json.dump({"scoring": {"threshold": 7.5}}, f)
+
+        resp = client.get("/settings/config")
+        body = resp.data.decode()
+        assert "<textarea" in body
+        assert "7.5" in body
+
+    def test_masks_app_id_field(self, client, tmp_config_path):
+        with open(tmp_config_path, "w") as f:
+            json.dump({"adzuna_app_id": "real-id-secret", "adzuna_app_key": "real-key-secret"}, f)
+
+        resp = client.get("/settings/config")
+        body = resp.data.decode()
+        assert "real-id-secret" not in body
+        assert "real-key-secret" not in body
+        assert "***" in body
+
+    def test_masks_api_key_field(self, client, tmp_config_path):
+        with open(tmp_config_path, "w") as f:
+            json.dump({"some_api_key": "super-secret-api-key"}, f)
+
+        resp = client.get("/settings/config")
+        body = resp.data.decode()
+        assert "super-secret-api-key" not in body
+        assert "***" in body
+
+    def test_non_sensitive_fields_are_visible(self, client, tmp_config_path):
+        with open(tmp_config_path, "w") as f:
+            json.dump({"scoring": {"threshold": 8.0}, "adzuna_app_id": "secret"}, f)
+
+        resp = client.get("/settings/config")
+        body = resp.data.decode()
+        assert "8.0" in body
+
+    def test_settings_config_link_on_settings_page(self, client, tmp_keys_path, tmp_config_path):
+        """The /settings page must contain a link to /settings/config."""
+        resp = client.get("/settings")
+        body = resp.data.decode()
+        assert "/settings/config" in body
+
+    def test_works_when_config_absent(self, client, tmp_config_path):
+        """GET should still return 200 even when config.json does not exist."""
+        assert not os.path.exists(tmp_config_path)
+        resp = client.get("/settings/config")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /settings/config (#21)
+# ---------------------------------------------------------------------------
+
+class TestSettingsConfigPost:
+    """Tests for the POST /settings/config route."""
+
+    def test_valid_json_updates_file(self, client, tmp_config_path):
+        original = {"scoring": {"threshold": 7.0}, "adzuna_app_id": "orig-id"}
+        with open(tmp_config_path, "w") as f:
+            json.dump(original, f)
+
+        new_config = json.dumps({"scoring": {"threshold": 9.0}, "adzuna_app_id": "orig-id"})
+        resp = client.post("/settings/config", data={"config_json": new_config})
+        assert resp.status_code == 200
+
+        with open(tmp_config_path) as f:
+            saved = json.load(f)
+        assert saved["scoring"]["threshold"] == 9.0
+
+    def test_valid_save_shows_success_notice(self, client, tmp_config_path):
+        resp = client.post(
+            "/settings/config",
+            data={"config_json": json.dumps({"scoring": {"threshold": 7.0}})},
+        )
+        body = resp.data.decode()
+        assert "saved" in body.lower()
+
+    def test_invalid_json_returns_400(self, client, tmp_config_path):
+        resp = client.post("/settings/config", data={"config_json": "not valid json {{{"})
+        assert resp.status_code == 400
+
+    def test_invalid_json_shows_error_message(self, client, tmp_config_path):
+        resp = client.post("/settings/config", data={"config_json": "not valid json {{{"})
+        body = resp.data.decode()
+        assert "Invalid JSON" in body
+
+    def test_invalid_json_leaves_file_unchanged(self, client, tmp_config_path):
+        original = {"scoring": {"threshold": 7.0}}
+        with open(tmp_config_path, "w") as f:
+            json.dump(original, f)
+
+        client.post("/settings/config", data={"config_json": "not valid json {{{"})
+
+        with open(tmp_config_path) as f:
+            after = json.load(f)
+        assert after == original
+
+    def test_masked_sentinel_not_written_to_disk(self, client, tmp_config_path):
+        """If a sensitive field still contains '***', the original value is preserved."""
+        original = {"adzuna_app_id": "keep-this-id", "adzuna_app_key": "keep-this-key"}
+        with open(tmp_config_path, "w") as f:
+            json.dump(original, f)
+
+        # Submit with the masked sentinel values (as the browser would receive them).
+        masked_submission = json.dumps({"adzuna_app_id": "***", "adzuna_app_key": "***"})
+        resp = client.post("/settings/config", data={"config_json": masked_submission})
+        assert resp.status_code == 200
+
+        with open(tmp_config_path) as f:
+            saved = json.load(f)
+        assert saved["adzuna_app_id"] == "keep-this-id"
+        assert saved["adzuna_app_key"] == "keep-this-key"
+
+    def test_response_never_contains_real_sensitive_values(self, client, tmp_config_path):
+        """After a successful POST the response must not echo raw sensitive values."""
+        original = {"adzuna_app_id": "do-not-echo-me"}
+        with open(tmp_config_path, "w") as f:
+            json.dump(original, f)
+
+        resp = client.post(
+            "/settings/config",
+            data={"config_json": json.dumps({"adzuna_app_id": "do-not-echo-me"})},
+        )
+        body = resp.data.decode()
+        assert "do-not-echo-me" not in body
+
+
+# ---------------------------------------------------------------------------
+# _mask_config_keys helper — unit tests (#21)
+# ---------------------------------------------------------------------------
+
+class TestMaskConfigKeys:
+    """Unit tests for the _mask_config_keys helper."""
+
+    def test_masks_app_id(self):
+        data = {"adzuna_app_id": "real-id"}
+        result = app_module._mask_config_keys(data)
+        assert result["adzuna_app_id"] == "***"
+
+    def test_masks_app_key(self):
+        data = {"adzuna_app_key": "real-key"}
+        result = app_module._mask_config_keys(data)
+        assert result["adzuna_app_key"] == "***"
+
+    def test_masks_api_key(self):
+        data = {"some_api_key": "sk-secret"}
+        result = app_module._mask_config_keys(data)
+        assert result["some_api_key"] == "***"
+
+    def test_case_insensitive_matching(self):
+        data = {"ADZUNA_APP_ID": "id-value", "My_API_Key": "key-value"}
+        result = app_module._mask_config_keys(data)
+        assert result["ADZUNA_APP_ID"] == "***"
+        assert result["My_API_Key"] == "***"
+
+    def test_non_sensitive_keys_unchanged(self):
+        data = {"scoring": {"threshold": 7.0}, "country": "us"}
+        result = app_module._mask_config_keys(data)
+        assert result["scoring"]["threshold"] == 7.0
+        assert result["country"] == "us"
+
+    def test_recursive_masking_in_nested_dict(self):
+        data = {"providers": {"anthropic": {"anthropic_api_key": "sk-secret", "model": "claude"}}}
+        result = app_module._mask_config_keys(data)
+        assert result["providers"]["anthropic"]["anthropic_api_key"] == "***"
+        assert result["providers"]["anthropic"]["model"] == "claude"
+
+    def test_does_not_mutate_original(self):
+        data = {"adzuna_app_id": "original"}
+        result = app_module._mask_config_keys(data)
+        assert data["adzuna_app_id"] == "original"
+        assert result["adzuna_app_id"] == "***"
+
+    def test_list_values_preserved(self):
+        data = {"title_exclude": ["junior", "intern"], "adzuna_app_id": "secret"}
+        result = app_module._mask_config_keys(data)
+        assert result["title_exclude"] == ["junior", "intern"]
+        assert result["adzuna_app_id"] == "***"
+
+
+# ---------------------------------------------------------------------------
 # _load_keys helper — unit tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `/settings/config` page to view and edit `config.json` via the browser
- API key fields masked in textarea to prevent accidental key exposure
- Invalid JSON rejected with inline error; file never overwritten on bad input

## Test plan
- [ ] `pytest` passes — load, valid save, invalid JSON, masking tests included
- [ ] Submitting valid JSON updates `config.json`
- [ ] Submitting invalid JSON shows error, leaves file unchanged
- [ ] Key fields show `***` in textarea

🤖 Generated with Claude Code