### PR TITLE
Chore: switch from pip to uv for package management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,19 +18,13 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Cache pip dependencies
-        uses: actions/cache@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          enable-cache: true
 
-      - name: Install runtime dependencies
-        run: pip install -r requirements.txt
-
-      - name: Install dev dependencies
-        run: pip install -r requirements-dev.txt
+      - name: Install dependencies
+        run: uv pip install -r requirements.txt -r requirements-dev.txt --system
 
       - name: Run linter
         run: ruff check .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```powershell
 # Install dependencies
-pip install -r requirements.txt
+uv pip install -r requirements.txt
 
 # Run ingestion pipeline (fetch → filter → scrape → score → store)
 python ingest.py

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ cd job_aggregator
 
 ```bash
 # bash / macOS / Linux
-python -m venv .venv
+uv venv
 source .venv/bin/activate
 
-# PowerShell
-python -m venv .venv
+# PowerShell (or: uv run python ...)
+uv venv
 .venv\Scripts\Activate.ps1
 ```
 
 **3. Install dependencies**
 
 ```bash
-pip install -r requirements.txt
+uv pip install -r requirements.txt
 ```
 
 **4. Copy the config files**
@@ -233,7 +233,7 @@ After the script completes, navigate to `http://localhost:5000/settings` to ente
 
 ### Prerequisites
 
-- Python venv already set up and `pip install -r requirements.txt` run
+- Python venv already set up and `uv pip install -r requirements.txt` run
 - `profile.json` present in the project root (`config.json` is created from the example by the script if absent)
 - [NSSM](https://nssm.cc/download) downloaded and either on `PATH` or referenced by full path
 
@@ -344,7 +344,7 @@ GitHub Actions CI runs (tests + linting)
 deploy.yml triggers on the self-hosted runner
         │
         ▼
-git pull → pip install → nssm restart JobMatcher
+git pull → uv pip install → nssm restart JobMatcher
 ```
 
 ### One-time runner setup

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -107,7 +107,7 @@ if (-not (Test-Path -Path $waitressExe -PathType Leaf)) {
     Write-Host 'Create and populate the venv before running setup:' -ForegroundColor Yellow
     Write-Host "  cd `"$ProjectRoot`""
     Write-Host '  python -m venv venv'
-    Write-Host '  venv\Scripts\pip install -r requirements.txt'
+    Write-Host '  uv pip install -r requirements.txt'
     Write-Host ''
     exit 1
 }
@@ -450,5 +450,5 @@ Write-Host ''
 # 5. Confirm outbound HTTPS to github.com is not blocked by firewall/proxy.
 #
 # Once registered, pushing to main will automatically:
-#   git pull -> pip install -r requirements.txt -> nssm restart JobMatcher
+#   git pull -> uv pip install -r requirements.txt -> nssm restart JobMatcher
 # ===========================================================================


### PR DESCRIPTION
## Summary
- CI now uses `astral-sh/setup-uv@v5` with built-in caching instead of pip + manual cache step
- All `pip install` references in README, setup.ps1, and CLAUDE.md updated to `uv pip install`
- `requirements.txt` unchanged — uv is a drop-in replacement, no lockfile migration needed

## Test plan
- [x] CI passes with uv install step
- [x] No functional changes to application code

🤖 Generated with Claude Code