### PR TITLE
Fix: grant pull-requests:write permission to reusable PR review workflow (#97)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -7,5 +7,8 @@ on:
 jobs:
   review:
     uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1
+    permissions:
+      contents: read
+      pull-requests: write
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a `permissions` block to `claude-pr-review.yml` so the reusable workflow can post review comments

## Root Cause

When a caller job invokes a reusable workflow via `uses:`, GitHub restricts it to only the permissions the caller explicitly declares. Without a `permissions` block the default is `none` for all scopes — the shared `claude-pr-review.yml` needs `pull-requests: write` to post comments, which was silently denied.

## Change

```yaml
jobs:
  review:
    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1
    permissions:
      contents: read
      pull-requests: write       # ← added
    secrets:
      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
```

## Test plan

- [ ] Open or update a PR — confirm no workflow validation error
- [ ] Confirm Claude posts a review comment via the shared workflow

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)