### PR TITLE
Fix: pass DB_PATH to NSSM service via AppEnvironmentExtra (#99)

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -297,6 +297,7 @@ try {
     & nssm set $ServiceName Start           SERVICE_AUTO_START
     & nssm set $ServiceName AppStdout       $webLog
     & nssm set $ServiceName AppStderr       $errorLog
+    & nssm set $ServiceName AppEnvironmentExtra "DB_PATH=$dbPath"
     Write-Ok 'Service configured.'
 }
 catch {


### PR DESCRIPTION
## Summary

- Adds `nssm set JobMatcher AppEnvironmentExtra "DB_PATH=<dbPath>"` to Step 9 of `setup.ps1`

## Root Cause

NSSM services do not inherit Machine-scope system environment variables. `setup.ps1` was setting `DB_PATH` via `[Environment]::SetEnvironmentVariable(..., 'Machine')` but never passing it to the service process via `AppEnvironmentExtra`. This caused `app.py` (NSSM service) to fall back to `./jobs.db` — an empty file — while `ingest.py` (Task Scheduler, SYSTEM account) correctly used `DB_PATH` and wrote jobs to `C:\ProgramData\JobMatcher\data\jobs.db`. The UI showed no listings despite a populated database.

## Change

One line added to the NSSM configuration block in Step 9:

```powershell
& nssm set $ServiceName AppEnvironmentExtra "DB_PATH=$dbPath"
```

`$dbPath` is already defined earlier in the script as `C:\ProgramData\JobMatcher\data\jobs.db`.

## Workaround for existing deployments

```powershell
nssm set JobMatcher AppEnvironmentExtra "DB_PATH=C:\ProgramData\JobMatcher\data\jobs.db"
nssm restart JobMatcher
```

## Test plan

- [x] Run `setup.ps1` on a clean machine; confirm `nssm get JobMatcher AppEnvironmentExtra` returns `DB_PATH=C:\ProgramData\JobMatcher\data\jobs.db`
- [x] Run ingest; confirm jobs appear in the web UI

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)