### PR TITLE
Fix: remove over-restrictive permissions block from PR review workflow (#102)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -7,8 +7,5 @@ on:
 jobs:
   review:
     uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1
-    permissions:
-      contents: read
-      pull-requests: write
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Removes the explicit `permissions` block from `claude-pr-review.yml`.

## Root Cause

When a caller job declares `permissions` on a `uses:` reusable workflow call, GitHub intersects the caller's permissions with those declared inside the called workflow — the called workflow cannot exceed the caller's set. The shared `cbeaulieu-gt/github-actions` workflow already declares the permissions `claude-code-action` needs internally. Adding a partial list on the caller side silently caps those permissions and breaks the action.

The `permissions` block was introduced in PR #98 to fix a `pull-requests: none` error, but the correct fix was to remove it entirely, not specify a partial list.

## Change

```diff
 jobs:
   review:
     uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1
-    permissions:
-      contents: read
-      pull-requests: write
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
```

## Test plan

- [ ] Open or update a PR — workflow runs without a permissions error
- [ ] Claude successfully posts a review comment

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)