### PR TITLE
Fix: restore full permissions block on Claude workflow files (#105)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -7,5 +7,10 @@ on:
 jobs:
   review:
     uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      id-token: write
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tag-claude.yml
+++ b/.github/workflows/tag-claude.yml
@@ -9,5 +9,10 @@ on:
 jobs:
   respond:
     uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      id-token: write
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Restores the `permissions` block to `claude-pr-review.yml` and adds it to `tag-claude.yml` with the full set of scopes `claude-code-action` requires.

## Root Cause

GitHub defaults write scopes to `none` on PR events. PR #103 removed the `permissions` block entirely under the assumption the shared reusable workflow would declare its own — but the caller's permissions act as a ceiling, and without explicit grants the called workflow cannot elevate them.

## Permissions added to both jobs

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
  id-token: write
```

- `pull-requests: write` — post review comments
- `issues: write` — post issue/PR comments
- `id-token: write` — OIDC authentication used internally by `claude-code-action`
- `contents: read` — read repo code for review context

## History

#97 → #98 (partial fix, `pull-requests: write` only) → #102 → #103 (removed block entirely, regression) → this PR (correct full set)

## Test plan

- [ ] Opening or updating a PR triggers Claude to post a review comment
- [ ] `@claude` in a PR comment triggers a response

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)