### PR TITLE
Feat: settings & filter form polish — heading semantics, a11y, auto-submit, auto-fade (#88)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -195,6 +195,29 @@ body {
   font-weight: normal;
 }
 
+.page-heading {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: normal;
+  color: var(--text-secondary);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0 0 20px;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 24px;
+}
+.page-breadcrumb {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+  padding: 0 0 20px;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 24px;
+}
+.page-breadcrumb a { color: var(--text-secondary); text-decoration: none; }
+.page-breadcrumb a:hover { color: var(--text-accent); text-decoration: underline; }
+
 /* ------------------------------------------------------------
    Listing cards
    ------------------------------------------------------------ */
@@ -1134,6 +1157,11 @@ body {
   margin-top: 4px;
 }
 
+@keyframes notice-fade-out {
+  0%, 75% { opacity: 1; }
+  100%    { opacity: 0; pointer-events: none; }
+}
+
 .save-notice {
   font-family: var(--font-mono);
   font-size: 0.76rem;
@@ -1145,6 +1173,7 @@ body {
   padding: 7px 14px;
   margin-bottom: 20px;
   max-width: 600px;
+  animation: notice-fade-out 4s ease forwards;
 }
 
 /* ------------------------------------------------------------

--- a/templates/_ingest_trigger.html
+++ b/templates/_ingest_trigger.html
@@ -23,8 +23,8 @@
       <input type="checkbox" name="rescore" value="1">
       Rescore all
     </label>
-    <label class="filter-toggle ingest-opt">
-      Period:&nbsp;<select name="hours" class="filter-select ingest-period-select">
+    <label class="filter-toggle ingest-opt" for="ingest-hours">
+      Period:&nbsp;<select id="ingest-hours" name="hours" class="filter-select ingest-period-select">
         <option value="25">Last 24 hours</option>
         <option value="73">Last 3 days</option>
         <option value="169" selected>Last 7 days</option>

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,7 +34,7 @@
       <strong>{{ listings | length }}</strong>
       {%- if listings | length == 1 %} role{% else %} roles{% endif %}
       &nbsp;·&nbsp;
-      scored {{ (min_score if min_score is not none else threshold) | round(1) }}+ &nbsp;·&nbsp; sorted by {% if sort == 'date_posted' %}date posted{% else %}match{% endif %}
+      scored {{ (min_score if min_score is not none else threshold) | round(1) }}+ &nbsp;·&nbsp; sorted by {% if sort == 'date_posted' %}date posted{% else %}score{% endif %}
       {%- if last_fetch_time is not none %}
         &nbsp;·&nbsp; <span class="last-fetch">last updated {{ last_fetch_time | timeago }}</span>
       {%- endif %}
@@ -67,7 +67,7 @@
       <input type="text" name="search" placeholder="Search title or company"
              value="{{ search or '' }}" class="filter-input">
 
-      <select name="min_score" class="filter-select">
+      <select name="min_score" class="filter-select" onchange="this.form.submit()">
         <option value="">Score: any</option>
         <option value="5" {% if min_score == 5.0 %}selected{% endif %}>5+</option>
         <option value="6" {% if min_score == 6.0 %}selected{% endif %}>6+</option>
@@ -76,13 +76,13 @@
         <option value="9" {% if min_score == 9.0 %}selected{% endif %}>9+</option>
       </select>
 
-      <select name="sort" class="filter-select">
+      <select name="sort" class="filter-select" onchange="this.form.submit()">
         <option value="" {% if not sort %}selected{% endif %}>Sort: score</option>
         <option value="date_posted" {% if sort == 'date_posted' %}selected{% endif %}>Sort: date posted</option>
       </select>
 
       {% if job_types %}
-      <select name="job_type" class="filter-select">
+      <select name="job_type" class="filter-select" onchange="this.form.submit()">
         <option value="">Role: all</option>
         {% for jt in job_types %}
           <option value="{{ jt }}" {% if job_type == jt %}selected{% endif %}>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -29,9 +29,7 @@
   </header>
 
   {# ── Page heading ─────────────────────────────────────────────── #}
-  <div class="feed-meta">
-    Settings
-  </div>
+  <h1 class="page-heading">Settings</h1>
 
   {# ── Success notice ───────────────────────────────────────────── #}
   {% if saved %}

--- a/templates/settings_config.html
+++ b/templates/settings_config.html
@@ -28,7 +28,7 @@
   </header>
 
   {# ── Breadcrumb ────────────────────────────────────────────── #}
-  <div class="feed-meta">
+  <div class="page-breadcrumb">
     <a href="/settings">Settings</a> &rsaquo; Config Editor
   </div>
 


### PR DESCRIPTION
## Summary

Five small quality-of-life fixes across the settings page and filter form.

## Changes

| File | Change |
|---|---|
| `static/style.css` | Add `.page-heading` + `.page-breadcrumb` classes; add 4s auto-fade animation to `.save-notice` |
| `templates/settings.html` | Replace `<div class="feed-meta">` with `<h1 class="page-heading">Settings</h1>` |
| `templates/settings_config.html` | Replace `<div class="feed-meta">` breadcrumb with `<div class="page-breadcrumb">` |
| `templates/_ingest_trigger.html` | Add explicit `for`/`id` association to the period select label |
| `templates/index.html` | "sorted by match" → "sorted by score"; add `onchange="this.form.submit()"` to `min_score`, `sort`, `job_type` selects |

## Test plan

- [ ] `/settings` shows "SETTINGS" as a proper page heading
- [ ] `/settings/config` shows breadcrumb with working back-link to Settings
- [ ] Clicking the "Period:" label focuses the select
- [ ] Feed meta reads "sorted by score"
- [ ] Changing any filter dropdown immediately reloads the feed without clicking Filter
- [ ] "Settings saved." banner fades out after ~3 seconds

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)