### PR TITLE
Fix: grant contents:write to tag-claude workflow (#113)

### DIFF
--- a/.github/workflows/tag-claude.yml
+++ b/.github/workflows/tag-claude.yml
@@ -10,7 +10,7 @@ jobs:
   respond:
     uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.1.0
     permissions:
-      contents: read
+      contents: write
       issues: write
       pull-requests: write
       id-token: write


### PR DESCRIPTION
## Summary

Changes `contents: read` → `contents: write` in `tag-claude.yml` so Claude can push code changes when asked via `@claude` comments.

## Change

```diff
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
   id-token: write
```

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)