### PR TITLE
Feat: move ingestion trigger from Settings to Feed page (#89)

### DIFF
--- a/app.py
+++ b/app.py
@@ -286,6 +286,7 @@ def feed():
         sort=sort,
         last_fetch_time=last_fetch_time,
         config_warnings=_config_warnings(),
+        running=_ingest_running(),
     )
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -106,6 +106,14 @@
     </form>
   {% endif %}
 
+  {# ── Ingestion trigger (feed only) ──────────────────────────── #}
+  {% if view == "feed" %}
+    <div class="ingest-trigger-container"
+         hx-on:ingestComplete="window.location.reload()">
+      {% include "_ingest_trigger.html" %}
+    </div>
+  {% endif %}
+
   {# ── Listing cards ───────────────────────────────────────────── #}
   {% if listings %}
     <div class="card-list">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -41,12 +41,6 @@
     <p class="save-error">{{ error }}</p>
   {% endif %}
 
-  {# ── Ingestion trigger ────────────────────────────────────────── #}
-  <div class="settings-section">
-    <h2 class="settings-section-title">Ingestion</h2>
-    {% include "_ingest_trigger.html" %}
-  </div>
-
   {# ── Settings form ────────────────────────────────────────────── #}
   <form class="settings-form" method="post" action="/settings">
 


### PR DESCRIPTION
## Summary

- Moves the "Run Ingestion" button + rescore/hours controls from the Settings page to the Feed page, where it logically belongs
- Feed page now passes `running=_ingest_running()` to its template context so the `_ingest_trigger.html` partial renders correctly
- Added `hx-on:ingestComplete` on the trigger container so the feed auto-refreshes when ingest finishes
- Removed the Ingestion `<div class="settings-section">` block from `settings.html`

## Test plan

- [ ] Feed page shows "Run Ingestion" button below the filter bar
- [ ] Clicking "Run Ingestion" shows the spinner and starts ingestion
- [ ] When ingest completes, feed auto-refreshes with new listings
- [ ] Settings page no longer has an Ingestion section

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)