### PR TITLE
Feat: two-row card summary layout, fix overflow (#118)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -847,7 +847,7 @@ body {
 /* Summary row — collapsed one-liner */
 .card-summary {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   padding: 13px 18px;
   cursor: pointer;
@@ -856,6 +856,15 @@ body {
 
 .card-summary:hover {
   background-color: var(--bg-hover);
+}
+
+/* Two-row column: title on top, meta below */
+.summary-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 /* Compact score badge used inside summary */
@@ -869,6 +878,7 @@ body {
   border-radius: 20px;
   border: 1px solid transparent;
   white-space: nowrap;
+  margin-top: 2px;
 }
 
 /* Reuse tier colour classes from the regular .score-badge */
@@ -904,11 +914,9 @@ body {
   font-size: 0.93rem;
   font-weight: 600;
   color: var(--text-primary);
-  flex: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  min-width: 0;
 }
 
 /* Company · location · salary in summary */
@@ -917,11 +925,10 @@ body {
   font-size: 0.72rem;
   color: var(--text-secondary);
   letter-spacing: 0.02em;
-  white-space: nowrap;
   display: flex;
   align-items: center;
   gap: 0 5px;
-  flex-shrink: 0;
+  flex-wrap: wrap;
 }
 
 .summary-company,
@@ -970,6 +977,7 @@ body {
   border-radius: 20px;
   border: 1px solid transparent;
   white-space: nowrap;
+  margin-top: 2px;
 }
 
 .badge-remote {
@@ -997,6 +1005,7 @@ body {
   white-space: nowrap;
   background: var(--bg-raised);
   color: var(--text-muted);
+  margin-top: 2px;
 }
 
 /* Model used badge — monospace, dimmer than badge-jobtype, no uppercase */

--- a/templates/_card.html
+++ b/templates/_card.html
@@ -36,22 +36,24 @@
       {%- endif -%}
     </span>
 
-    <span class="summary-title">{{ listing.title }}</span>
+    <span class="summary-main">
+      <span class="summary-title">{{ listing.title }}</span>
 
-    <span class="summary-meta">
-      {%- if listing.company -%}
-        <span class="summary-company">{{ listing.company }}</span>
-      {%- endif -%}
-      {%- if listing.company and listing.location -%}
-        <span class="sep">·</span>
-      {%- endif -%}
-      {%- if listing.location -%}
-        <span class="summary-location">{{ listing.location }}</span>
-      {%- endif -%}
-      {%- if salary -%}
-        <span class="sep">·</span>
-        <span class="salary{% if listing.salary_is_predicted %} predicted{% endif %}">{{ salary }}</span>
-      {%- endif -%}
+      <span class="summary-meta">
+        {%- if listing.company -%}
+          <span class="summary-company">{{ listing.company }}</span>
+        {%- endif -%}
+        {%- if listing.company and listing.location -%}
+          <span class="sep">·</span>
+        {%- endif -%}
+        {%- if listing.location -%}
+          <span class="summary-location">{{ listing.location }}</span>
+        {%- endif -%}
+        {%- if salary -%}
+          <span class="sep">·</span>
+          <span class="salary{% if listing.salary_is_predicted %} predicted{% endif %}">{{ salary }}</span>
+        {%- endif -%}
+      </span>
     </span>
 
     {% if is_remote %}
@@ -62,10 +64,6 @@
 
     {% if listing.job_type %}
       <span class="badge-jobtype">{{ listing.job_type | title }}</span>
-    {% endif %}
-
-    {% if listing.model_used %}
-      <span class="model-badge">{{ listing.model_used.split('/')[-1] }}</span>
     {% endif %}
 
   </summary>


### PR DESCRIPTION
## Summary

Restructures the collapsed card summary from a single overflowing flex row into a deliberate two-row layout:

```
[score]  Job Title Here                    [Remote] [Full-time]
         Company · Location · £60k–80k
```

### `templates/_card.html`
- Wrapped `summary-title` + `summary-meta` in a new `<span class="summary-main">` column
- Removed `model-badge` from the summary (will move to expanded card body in #87)

### `static/style.css`
- `.card-summary` — `align-items: center` → `align-items: flex-start` (pins score badge and right badges to title baseline)
- `.summary-main` (new) — `flex: 1; flex-direction: column; gap: 3px`
- `.summary-title` — removed `flex: 1` and `min-width: 0` (now on parent `.summary-main`)
- `.summary-meta` — removed `flex-shrink: 0` and `white-space: nowrap`; added `flex-wrap: wrap`
- `.score-badge--sm`, `.badge-remote`, `.badge-onsite`, `.badge-jobtype` — `margin-top: 2px` for optical alignment with title

## Test plan

- [ ] Each card summary shows title on line 1, company/location/salary on line 2
- [ ] Score badge and remote/job-type badges are top-aligned, not vertically centred
- [ ] No overflow or horizontal scrollbar at typical desktop widths
- [ ] Cards with missing company/location/salary render cleanly (no orphan separators)
- [ ] Expanding/collapsing cards still works correctly

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)