### PR TITLE
Chore: bump shared Claude Actions refs to v1.2.0 (#120)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.1.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.2.0
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/tag-claude.yml
+++ b/.github/workflows/tag-claude.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   respond:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.1.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.2.0
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary

Bumps both shared reusable workflow refs from `@v1.1.0` → `@v1.2.0`:

- `.github/workflows/claude-pr-review.yml`
- `.github/workflows/tag-claude.yml`

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)