### PR TITLE
Fix: rename settings section heading to 'LLM Providers' (#91)

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -81,7 +81,7 @@
         placeholder="Enter new App Key to update (leave blank to keep existing)">
     </div>
 
-    <h2 class="settings-section-title">API Keys &amp; Models</h2>
+    <h2 class="settings-section-title">LLM Providers</h2>
 
     {# ── Anthropic ── #}
     <div class="provider-row">


### PR DESCRIPTION
## Summary

Single heading rename in `templates/settings.html`:

- `"API Keys & Models"` → `"LLM Providers"`

The validate section was already correctly positioned immediately after the Save button (the #89/#90 restructure left it clean), and no inline `style` attributes were present — no further changes needed.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)