### PR TITLE
Chore: bump shared Claude Actions refs to v1.3.0

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.2.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.3.0
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/tag-claude.yml
+++ b/.github/workflows/tag-claude.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   respond:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.2.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.3.0
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary
- Bumps `claude-pr-review.yml` from `@v1.2.0` → `@v1.3.0`
- Bumps `tag-claude.yml` from `@v1.2.0` → `@v1.3.0`

## Test plan
- [ ] Verify CI passes
- [ ] Open a test PR to confirm the PR review workflow triggers correctly
- [ ] Tag `@claude` in a comment to confirm the tag-respond workflow fires

closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)