### PR TITLE
Fix missing redirect_url index and non-atomic bookmark/apply toggles

### DIFF
--- a/app.py
+++ b/app.py
@@ -307,20 +307,13 @@ def bookmarks():
 def toggle_bookmark(listing_id: int):
     """Toggle the bookmarked state for a listing.
 
-    Reads the current state, flips it, writes it back, then returns the
-    re-rendered action button group as an HTMX partial. HTMX swaps this
-    into the DOM in place of the existing action row, so the star icon
-    updates without a full page reload.
+    Uses an atomic SQL flip (``1 - bookmarked``) to avoid the race condition
+    where two rapid clicks both read the same initial state and cancel each
+    other out. Returns the re-rendered action button group as an HTMX partial.
     """
-    listing = db.get_listing_by_id(listing_id, db_path=DB_PATH)
+    listing = db.toggle_bookmarked(listing_id, db_path=DB_PATH)
     if listing is None:
         return make_response("", 404)
-
-    new_value = 0 if listing["bookmarked"] else 1
-    db.set_bookmarked(listing_id, new_value, db_path=DB_PATH)
-
-    # Re-fetch to get the authoritative updated state.
-    listing = db.get_listing_by_id(listing_id, db_path=DB_PATH)
     return render_template("_actions.html", listing=listing)
 
 
@@ -328,19 +321,13 @@ def toggle_bookmark(listing_id: int):
 def toggle_apply(listing_id: int):
     """Toggle the applied state for a listing.
 
-    Reads the current state, flips it, writes it back, then returns the
-    re-rendered action button group as an HTMX partial. Same read-modify-write
-    pattern as toggle_bookmark — only the action row is swapped in the DOM.
+    Uses an atomic SQL flip (``1 - applied``) to avoid the race condition
+    where two rapid clicks both read the same initial state and cancel each
+    other out. Returns the re-rendered action button group as an HTMX partial.
     """
-    listing = db.get_listing_by_id(listing_id, db_path=DB_PATH)
+    listing = db.toggle_applied(listing_id, db_path=DB_PATH)
     if listing is None:
         return make_response("", 404)
-
-    new_value = 0 if listing["applied"] else 1
-    db.set_applied(listing_id, new_value, db_path=DB_PATH)
-
-    # Re-fetch to get the authoritative updated state.
-    listing = db.get_listing_by_id(listing_id, db_path=DB_PATH)
     return render_template("_actions.html", listing=listing)
 
 

--- a/db.py
+++ b/db.py
@@ -324,6 +324,13 @@ def init_db(db_path: str = _DEFAULT_DB_PATH) -> None:
                 except sqlite3.OperationalError:
                     pass  # Column already present; nothing to do.
 
+        # Index for cross-source dedup lookup used by listing_exists_by_url().
+        # CREATE INDEX IF NOT EXISTS is idempotent — safe on any existing DB.
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_listings_redirect_url "
+            "ON listings (redirect_url)"
+        )
+
         conn.commit()
     finally:
         conn.close()
@@ -820,3 +827,41 @@ def get_applied(db_path: str = _DEFAULT_DB_PATH) -> list[dict]:
         return [_deserialise_row(r) for r in rows]
     finally:
         conn.close()
+
+
+def toggle_bookmarked(listing_id: int, db_path: str = _DEFAULT_DB_PATH) -> dict | None:
+    """Atomically flip the bookmarked flag and return the updated listing.
+
+    Uses a single ``UPDATE … SET bookmarked = 1 - bookmarked`` statement so
+    concurrent clicks cannot cancel each other the way a read-flip-write
+    sequence can.  Returns the refreshed row, or None if the id does not exist.
+    """
+    conn = get_connection(db_path)
+    try:
+        conn.execute(
+            "UPDATE listings SET bookmarked = 1 - bookmarked WHERE id = ?",
+            (listing_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return get_listing_by_id(listing_id, db_path=db_path)
+
+
+def toggle_applied(listing_id: int, db_path: str = _DEFAULT_DB_PATH) -> dict | None:
+    """Atomically flip the applied flag and return the updated listing.
+
+    Uses a single ``UPDATE … SET applied = 1 - applied`` statement so
+    concurrent clicks cannot cancel each other the way a read-flip-write
+    sequence can.  Returns the refreshed row, or None if the id does not exist.
+    """
+    conn = get_connection(db_path)
+    try:
+        conn.execute(
+            "UPDATE listings SET applied = 1 - applied WHERE id = ?",
+            (listing_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return get_listing_by_id(listing_id, db_path=db_path)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -918,3 +918,111 @@ class TestPostedAt:
             # real-pa has a non-NULL posted_at so should sort first (DESC puts NULLs last)
             assert ids[0] == "real-pa"
             assert "null-pa" in ids
+
+
+# ---------------------------------------------------------------------------
+# Issue #132 — redirect_url index
+# ---------------------------------------------------------------------------
+
+class TestRedirectUrlIndex:
+    def test_index_exists_after_init_db(self):
+        """init_db() creates idx_listings_redirect_url on the listings table."""
+        with TempDB() as path:
+            conn = db.get_connection(path)
+            try:
+                row = conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='index' AND name='idx_listings_redirect_url'"
+                ).fetchone()
+                assert row is not None, "idx_listings_redirect_url index was not created"
+            finally:
+                conn.close()
+
+    def test_index_idempotent(self):
+        """Calling init_db() twice does not raise due to the redirect_url index."""
+        with TempDB() as path:
+            db.init_db(path)  # second call — IF NOT EXISTS makes this safe
+
+
+# ---------------------------------------------------------------------------
+# Issue #134 — atomic bookmark/apply toggles
+# ---------------------------------------------------------------------------
+
+class TestAtomicToggles:
+    def _get_listing_id(self, path: str, source_id: str) -> int:
+        conn = db.get_connection(path)
+        try:
+            row = conn.execute(
+                "SELECT id FROM listings WHERE source_id = ?", (source_id,)
+            ).fetchone()
+            return row["id"]
+        finally:
+            conn.close()
+
+    def test_toggle_bookmarked_flips_from_zero_to_one(self):
+        """toggle_bookmarked() sets bookmarked=1 when starting from 0."""
+        with TempDB() as path:
+            db.insert_listing(make_listing(source_id="tb-001", bookmarked=0), db_path=path)
+            lid = self._get_listing_id(path, "tb-001")
+            result = db.toggle_bookmarked(lid, db_path=path)
+            assert result is not None
+            assert result["bookmarked"] == 1
+
+    def test_toggle_bookmarked_flips_from_one_to_zero(self):
+        """toggle_bookmarked() sets bookmarked=0 when starting from 1."""
+        with TempDB() as path:
+            db.insert_listing(make_listing(source_id="tb-002", bookmarked=1), db_path=path)
+            lid = self._get_listing_id(path, "tb-002")
+            result = db.toggle_bookmarked(lid, db_path=path)
+            assert result is not None
+            assert result["bookmarked"] == 0
+
+    def test_toggle_bookmarked_twice_returns_to_original(self):
+        """Two rapid toggle_bookmarked() calls produce a net no-op (each flip is independent)."""
+        with TempDB() as path:
+            db.insert_listing(make_listing(source_id="tb-003", bookmarked=0), db_path=path)
+            lid = self._get_listing_id(path, "tb-003")
+            db.toggle_bookmarked(lid, db_path=path)   # 0 → 1
+            result = db.toggle_bookmarked(lid, db_path=path)  # 1 → 0
+            assert result is not None
+            assert result["bookmarked"] == 0
+
+    def test_toggle_bookmarked_returns_none_for_missing_id(self):
+        """toggle_bookmarked() returns None when the listing id does not exist."""
+        with TempDB() as path:
+            result = db.toggle_bookmarked(99999, db_path=path)
+            assert result is None
+
+    def test_toggle_applied_flips_from_zero_to_one(self):
+        """toggle_applied() sets applied=1 when starting from 0."""
+        with TempDB() as path:
+            db.insert_listing(make_listing(source_id="ta-001", applied=0), db_path=path)
+            lid = self._get_listing_id(path, "ta-001")
+            result = db.toggle_applied(lid, db_path=path)
+            assert result is not None
+            assert result["applied"] == 1
+
+    def test_toggle_applied_flips_from_one_to_zero(self):
+        """toggle_applied() sets applied=0 when starting from 1."""
+        with TempDB() as path:
+            db.insert_listing(make_listing(source_id="ta-002", applied=1), db_path=path)
+            lid = self._get_listing_id(path, "ta-002")
+            result = db.toggle_applied(lid, db_path=path)
+            assert result is not None
+            assert result["applied"] == 0
+
+    def test_toggle_applied_twice_returns_to_original(self):
+        """Two rapid toggle_applied() calls produce a net no-op (each flip is independent)."""
+        with TempDB() as path:
+            db.insert_listing(make_listing(source_id="ta-003", applied=0), db_path=path)
+            lid = self._get_listing_id(path, "ta-003")
+            db.toggle_applied(lid, db_path=path)   # 0 → 1
+            result = db.toggle_applied(lid, db_path=path)  # 1 → 0
+            assert result is not None
+            assert result["applied"] == 0
+
+    def test_toggle_applied_returns_none_for_missing_id(self):
+        """toggle_applied() returns None when the listing id does not exist."""
+        with TempDB() as path:
+            result = db.toggle_applied(99999, db_path=path)
+            assert result is None


### PR DESCRIPTION
## Summary

- **fixes #132** — Add `CREATE INDEX IF NOT EXISTS idx_listings_redirect_url ON listings (redirect_url)` to `init_db()`. Dedup check during ingest was doing a full table scan per listing; now O(log n).
- **fixes #134** — Replace read-flip-write toggle in `app.py` with atomic `UPDATE listings SET bookmarked = 1 - bookmarked WHERE id = ?` (and same for `applied`). Two rapid clicks no longer produce a net no-op.

## Test plan

- [ ] Run `pytest` — 57 tests passing
- [ ] Verify index exists on `redirect_url` after `init_db()` via `.schema` or `EXPLAIN QUERY PLAN`
- [ ] Verify rapid double-click on bookmark correctly toggles twice (net same state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)