### PR TITLE
Fix: atomic bookmark/apply toggles to prevent double-click no-op (#134)

### DIFF
--- a/app.py
+++ b/app.py
@@ -309,20 +309,13 @@ def bookmarks():
 def toggle_bookmark(listing_id: int):
     """Toggle the bookmarked state for a listing.
 
-    Reads the current state, flips it, writes it back, then returns the
-    re-rendered action button group as an HTMX partial. HTMX swaps this
-    into the DOM in place of the existing action row, so the star icon
-    updates without a full page reload.
+    Delegates to db.toggle_bookmarked(), which performs the flip atomically
+    in a single SQL statement so rapid double-clicks cannot produce a net
+    no-op. Returns the re-rendered action button group as an HTMX partial.
     """
-    listing = db.get_listing_by_id(listing_id, db_path=DB_PATH)
+    listing = db.toggle_bookmarked(listing_id, db_path=DB_PATH)
     if listing is None:
         return make_response("", 404)
-
-    new_value = 0 if listing["bookmarked"] else 1
-    db.set_bookmarked(listing_id, new_value, db_path=DB_PATH)
-
-    # Re-fetch to get the authoritative updated state.
-    listing = db.get_listing_by_id(listing_id, db_path=DB_PATH)
     return render_template("_actions.html", listing=listing)
 
 
@@ -330,19 +323,13 @@ def toggle_bookmark(listing_id: int):
 def toggle_apply(listing_id: int):
     """Toggle the applied state for a listing.
 
-    Reads the current state, flips it, writes it back, then returns the
-    re-rendered action button group as an HTMX partial. Same read-modify-write
-    pattern as toggle_bookmark — only the action row is swapped in the DOM.
+    Delegates to db.toggle_applied(), which performs the flip atomically
+    in a single SQL statement so rapid double-clicks cannot produce a net
+    no-op. Returns the re-rendered action button group as an HTMX partial.
     """
-    listing = db.get_listing_by_id(listing_id, db_path=DB_PATH)
+    listing = db.toggle_applied(listing_id, db_path=DB_PATH)
     if listing is None:
         return make_response("", 404)
-
-    new_value = 0 if listing["applied"] else 1
-    db.set_applied(listing_id, new_value, db_path=DB_PATH)
-
-    # Re-fetch to get the authoritative updated state.
-    listing = db.get_listing_by_id(listing_id, db_path=DB_PATH)
     return render_template("_actions.html", listing=listing)
 
 

--- a/db.py
+++ b/db.py
@@ -806,6 +806,58 @@ def set_applied(listing_id: int, value: int, db_path: str = _DEFAULT_DB_PATH) ->
         conn.close()
 
 
+def toggle_bookmarked(listing_id: int, db_path: str = _DEFAULT_DB_PATH) -> dict | None:
+    """Atomically flip the bookmarked flag and return the updated listing.
+
+    Uses a single SQL statement (``1 - bookmarked``) so concurrent requests
+    cannot both read the same state and both write the same flipped value —
+    the race condition that the read-flip-write pattern is vulnerable to.
+
+    Args:
+        listing_id: Internal integer primary key.
+        db_path:    Path to the SQLite database file.
+
+    Returns:
+        The updated listing dict, or None if the id does not exist.
+    """
+    conn = get_connection(db_path)
+    try:
+        conn.execute(
+            "UPDATE listings SET bookmarked = 1 - bookmarked WHERE id = ?",
+            (listing_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return get_listing_by_id(listing_id, db_path=db_path)
+
+
+def toggle_applied(listing_id: int, db_path: str = _DEFAULT_DB_PATH) -> dict | None:
+    """Atomically flip the applied flag and return the updated listing.
+
+    Uses a single SQL statement (``1 - applied``) so concurrent requests
+    cannot both read the same state and both write the same flipped value —
+    the race condition that the read-flip-write pattern is vulnerable to.
+
+    Args:
+        listing_id: Internal integer primary key.
+        db_path:    Path to the SQLite database file.
+
+    Returns:
+        The updated listing dict, or None if the id does not exist.
+    """
+    conn = get_connection(db_path)
+    try:
+        conn.execute(
+            "UPDATE listings SET applied = 1 - applied WHERE id = ?",
+            (listing_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return get_listing_by_id(listing_id, db_path=db_path)
+
+
 def get_applied(db_path: str = _DEFAULT_DB_PATH) -> list[dict]:
     """Return all listings where applied = 1, ordered by fetched_at DESC."""
     conn = get_connection(db_path)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -918,3 +918,119 @@ class TestPostedAt:
             # real-pa has a non-NULL posted_at so should sort first (DESC puts NULLs last)
             assert ids[0] == "real-pa"
             assert "null-pa" in ids
+
+
+# ---------------------------------------------------------------------------
+# Atomic toggle helpers
+# ---------------------------------------------------------------------------
+
+class TestToggleBookmarked:
+    """Tests for db.toggle_bookmarked() — atomic flip of the bookmarked flag."""
+
+    def _insert_and_get_id(self, path: str, source_id: str, bookmarked: int = 0) -> int:
+        db.insert_listing(make_listing(source_id=source_id, bookmarked=bookmarked), db_path=path)
+        conn = db.get_connection(path)
+        try:
+            row = conn.execute(
+                "SELECT id FROM listings WHERE source_id = ?", (source_id,)
+            ).fetchone()
+            return row["id"]
+        finally:
+            conn.close()
+
+    def test_toggle_bookmarked_flips_zero_to_one(self):
+        """toggle_bookmarked() on an unbookmarked listing sets bookmarked=1."""
+        with TempDB() as path:
+            listing_id = self._insert_and_get_id(path, "tb-001", bookmarked=0)
+            result = db.toggle_bookmarked(listing_id, db_path=path)
+            assert result is not None
+            assert result["bookmarked"] == 1
+
+    def test_toggle_bookmarked_flips_one_to_zero(self):
+        """toggle_bookmarked() on an already-bookmarked listing sets bookmarked=0."""
+        with TempDB() as path:
+            listing_id = self._insert_and_get_id(path, "tb-002", bookmarked=1)
+            result = db.toggle_bookmarked(listing_id, db_path=path)
+            assert result is not None
+            assert result["bookmarked"] == 0
+
+    def test_toggle_bookmarked_twice_returns_to_original(self):
+        """Two sequential toggle_bookmarked() calls return the flag to its original value."""
+        with TempDB() as path:
+            listing_id = self._insert_and_get_id(path, "tb-003", bookmarked=0)
+            db.toggle_bookmarked(listing_id, db_path=path)
+            result = db.toggle_bookmarked(listing_id, db_path=path)
+            assert result is not None
+            assert result["bookmarked"] == 0
+
+    def test_toggle_bookmarked_returns_none_for_missing_id(self):
+        """toggle_bookmarked() returns None when the listing id does not exist."""
+        with TempDB() as path:
+            result = db.toggle_bookmarked(999999, db_path=path)
+            assert result is None
+
+    def test_toggle_bookmarked_returns_full_listing_dict(self):
+        """The dict returned by toggle_bookmarked() has the expected listing fields."""
+        with TempDB() as path:
+            listing_id = self._insert_and_get_id(path, "tb-004", bookmarked=0)
+            result = db.toggle_bookmarked(listing_id, db_path=path)
+            assert result is not None
+            assert result["source_id"] == "tb-004"
+            assert "score" in result
+            assert isinstance(result["matched_skills"], list)
+
+
+class TestToggleApplied:
+    """Tests for db.toggle_applied() — atomic flip of the applied flag."""
+
+    def _insert_and_get_id(self, path: str, source_id: str, applied: int = 0) -> int:
+        db.insert_listing(make_listing(source_id=source_id, applied=applied), db_path=path)
+        conn = db.get_connection(path)
+        try:
+            row = conn.execute(
+                "SELECT id FROM listings WHERE source_id = ?", (source_id,)
+            ).fetchone()
+            return row["id"]
+        finally:
+            conn.close()
+
+    def test_toggle_applied_flips_zero_to_one(self):
+        """toggle_applied() on an unapplied listing sets applied=1."""
+        with TempDB() as path:
+            listing_id = self._insert_and_get_id(path, "ta-001", applied=0)
+            result = db.toggle_applied(listing_id, db_path=path)
+            assert result is not None
+            assert result["applied"] == 1
+
+    def test_toggle_applied_flips_one_to_zero(self):
+        """toggle_applied() on an applied listing sets applied=0."""
+        with TempDB() as path:
+            listing_id = self._insert_and_get_id(path, "ta-002", applied=1)
+            result = db.toggle_applied(listing_id, db_path=path)
+            assert result is not None
+            assert result["applied"] == 0
+
+    def test_toggle_applied_twice_returns_to_original(self):
+        """Two sequential toggle_applied() calls return the flag to its original value."""
+        with TempDB() as path:
+            listing_id = self._insert_and_get_id(path, "ta-003", applied=0)
+            db.toggle_applied(listing_id, db_path=path)
+            result = db.toggle_applied(listing_id, db_path=path)
+            assert result is not None
+            assert result["applied"] == 0
+
+    def test_toggle_applied_returns_none_for_missing_id(self):
+        """toggle_applied() returns None when the listing id does not exist."""
+        with TempDB() as path:
+            result = db.toggle_applied(999999, db_path=path)
+            assert result is None
+
+    def test_toggle_applied_returns_full_listing_dict(self):
+        """The dict returned by toggle_applied() has the expected listing fields."""
+        with TempDB() as path:
+            listing_id = self._insert_and_get_id(path, "ta-004", applied=0)
+            result = db.toggle_applied(listing_id, db_path=path)
+            assert result is not None
+            assert result["source_id"] == "ta-004"
+            assert "score" in result
+            assert isinstance(result["matched_skills"], list)


### PR DESCRIPTION
## Summary

- Adds `toggle_bookmarked()` and `toggle_applied()` to `db.py`, each using a single `UPDATE … SET col = 1 - col` statement so the flip is atomic — concurrent requests cannot both read the same initial state and both write the same value back
- Updates `toggle_bookmark` and `toggle_apply` routes in `app.py` to call the new helpers instead of the old read-flip-write sequence
- Adds 10 new tests in `tests/test_db.py` covering: flip 0→1, flip 1→0, double-call returning to original, missing-id returning `None`, and full dict shape on return

## Root cause

The previous routes read `bookmarked`/`applied`, computed the negation in Python, then wrote it back in a separate statement. Two rapid clicks could both read the same value and both write the same flipped value — a net no-op. Pushing the flip into a single SQL expression makes it atomic at the database level.

## Test plan

- [x] `pytest tests/test_db.py` — 57 passed (47 existing + 10 new)
- [x] No regressions in `tests/test_settings.py`, `tests/test_ingest_trigger.py`, or job-source tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)