### PR TITLE
Test: integration tests for ingest.run() orchestrator (fixes #137)

### DIFF
--- a/tests/test_ingest_run.py
+++ b/tests/test_ingest_run.py
@@ -22,10 +22,7 @@ import json
 import os
 import re
 import sys
-import tempfile
-from unittest.mock import patch, MagicMock
-
-import pytest
+from unittest.mock import patch
 
 # Ensure the project root is on the path regardless of how pytest is invoked.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))


### PR DESCRIPTION
## Summary

- Adds `tests/test_ingest_run.py` with 9 integration tests for `ingest.run()`, which previously had zero test coverage
- Tests exercise the full orchestrator path: mock `JobSource` → prefilter → dedup → scrape → score → DB insert
- Uses a real temp SQLite database (pytest `tmp_path`) and patches `scrape_description` + `score_listing_with_fallback` at the `ingest` module level to avoid HTTP/LLM calls

## What is tested

**Happy path (2 listings):**
- Exact row count in DB after a run
- `db.get_feed()` returns the inserted listings with expected titles
- Printed summary line matches `app._INGEST_SUMMARY_RE` exactly (cross-module format validation)
- Persisted rows have correct `source`, `score`, and `seen=1` fields

**Score failure path:**
- Listing where `score_listing_with_fallback` returns `None` is stored with `seen=0` and `score=NULL`
- That listing does not appear in `get_feed()`
- Summary line reports `score_failed=1`

**Dedup path:**
- Running `run()` twice with identical listings produces only 2 rows (no duplicates)
- Second run's summary reports 2 dupes skipped

## Test plan

- [x] `pytest tests/test_ingest_run.py` — all 9 tests pass
- [x] `pytest` (full suite, rebased on current `main`) — 581 passed, 0 failures, 0 regressions
- [x] Branch rebased on top of #140 (pages() fix) now merged into `main`

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)