### PR TITLE
perf(db): add redirect_url index for fast cross-source dedup (fixes #132)

### DIFF
--- a/db.py
+++ b/db.py
@@ -324,6 +324,13 @@ def init_db(db_path: str = _DEFAULT_DB_PATH) -> None:
                 except sqlite3.OperationalError:
                     pass  # Column already present; nothing to do.
 
+        # Create index on redirect_url for fast cross-source deduplication.
+        # listing_exists_by_url() is called once per candidate listing during
+        # ingest; without this index every call is a full table scan.
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_listings_redirect_url ON listings (redirect_url)"
+        )
+
         conn.commit()
     finally:
         conn.close()

--- a/scripts/benchmark_index.py
+++ b/scripts/benchmark_index.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Benchmark: redirect_url index performance.
+
+Measures the time to check for duplicate listings via redirect_url
+with and without the index.
+
+Run from the project root:
+    python scripts/benchmark_index.py
+
+Benchmark results (contributed by @Alm0stSurely, PR #138):
+  Dataset: 10,000 listings, 500 existence queries
+  Without index: ~0.45s   With index: ~0.003s   Speedup: ~150x
+"""
+
+import os
+import tempfile
+import time
+
+import db
+
+
+def benchmark_without_index(num_listings: int, num_checks: int) -> float:
+    """Time listing_exists_by_url checks WITHOUT the index."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        conn = db.get_connection(db_path)
+
+        # Create table without index
+        conn.execute("""
+            CREATE TABLE listings (
+                id INTEGER PRIMARY KEY,
+                source TEXT,
+                source_id TEXT,
+                redirect_url TEXT,
+                title TEXT
+            )
+        """)
+
+        # Insert test data
+        for i in range(num_listings):
+            conn.execute(
+                "INSERT INTO listings (source, source_id, redirect_url, title) VALUES (?, ?, ?, ?)",
+                ("test", str(i), f"https://example.com/job/{i}", f"Job {i}")
+            )
+        conn.commit()
+
+        # Benchmark checks
+        start = time.perf_counter()
+        for i in range(num_checks):
+            url = f"https://example.com/job/{i % (num_listings * 2)}"  # 50% hit rate
+            conn.execute("SELECT 1 FROM listings WHERE redirect_url = ?", (url,)).fetchone()
+        elapsed = time.perf_counter() - start
+        conn.close()
+        return elapsed
+
+
+def benchmark_with_index(num_listings: int, num_checks: int) -> float:
+    """Time listing_exists_by_url checks WITH the index."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        conn = db.get_connection(db_path)
+
+        # Create table with index
+        conn.execute("""
+            CREATE TABLE listings (
+                id INTEGER PRIMARY KEY,
+                source TEXT,
+                source_id TEXT,
+                redirect_url TEXT,
+                title TEXT
+            )
+        """)
+        conn.execute("CREATE INDEX idx_listings_redirect_url ON listings (redirect_url)")
+
+        # Insert test data
+        for i in range(num_listings):
+            conn.execute(
+                "INSERT INTO listings (source, source_id, redirect_url, title) VALUES (?, ?, ?, ?)",
+                ("test", str(i), f"https://example.com/job/{i}", f"Job {i}")
+            )
+        conn.commit()
+
+        # Benchmark checks
+        start = time.perf_counter()
+        for i in range(num_checks):
+            url = f"https://example.com/job/{i % (num_listings * 2)}"  # 50% hit rate
+            conn.execute("SELECT 1 FROM listings WHERE redirect_url = ?", (url,)).fetchone()
+        elapsed = time.perf_counter() - start
+        conn.close()
+        return elapsed
+
+
+def main():
+    print("=" * 60)
+    print("Benchmark: redirect_url index performance")
+    print("=" * 60)
+
+    # Simulate: 10,000 stored listings, 500 checks per ingest run
+    num_listings = 10_000
+    num_checks = 500
+
+    print(f"\nDataset: {num_listings:,} listings")
+    print(f"Checks: {num_checks:,} existence queries")
+    print()
+
+    print("Running benchmark WITHOUT index...")
+    time_without = benchmark_without_index(num_listings, num_checks)
+    print(f"  Time: {time_without:.4f}s")
+
+    print("Running benchmark WITH index...")
+    time_with = benchmark_with_index(num_listings, num_checks)
+    print(f"  Time: {time_with:.4f}s")
+
+    print()
+    print("-" * 60)
+    speedup = time_without / time_with if time_with > 0 else float("inf")
+    improvement = ((time_without - time_with) / time_without * 100) if time_without > 0 else 0
+    print(f"Speedup: {speedup:.1f}x")
+    print(f"Time reduction: {improvement:.1f}%")
+    print("-" * 60)
+
+    # Verify query planner uses the index
+    print("\nQuery planner verification:")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        conn = db.get_connection(db_path)
+        conn.execute("""
+            CREATE TABLE listings (id INTEGER PRIMARY KEY, redirect_url TEXT)
+        """)
+        conn.execute("CREATE INDEX idx_listings_redirect_url ON listings (redirect_url)")
+        conn.execute("INSERT INTO listings (redirect_url) VALUES ('test')")
+        conn.commit()
+
+        plan = conn.execute(
+            "EXPLAIN QUERY PLAN SELECT 1 FROM listings WHERE redirect_url = ?",
+            ("test",)
+        ).fetchall()
+        for row in plan:
+            print(f"  {row['detail']}")
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -117,6 +117,17 @@ class TestInitDb:
             db.init_db(path)  # second call
             # If we get here without exception, the test passes.
 
+    def test_redirect_url_index_exists(self):
+        """init_db() creates the idx_listings_redirect_url index on the listings table."""
+        with TempDB() as path:
+            conn = db.get_connection(path)
+            try:
+                indexes = conn.execute("PRAGMA index_list(listings)").fetchall()
+                index_names = [row["name"] for row in indexes]
+                assert "idx_listings_redirect_url" in index_names
+            finally:
+                conn.close()
+
 
 # ---------------------------------------------------------------------------
 # listing_exists


### PR DESCRIPTION
## Summary

- Adds `CREATE INDEX IF NOT EXISTS idx_listings_redirect_url ON listings (redirect_url)` to `init_db()` so that `listing_exists_by_url()` uses an index scan instead of a full table scan on every ingest candidate check.
- Moves `benchmark_index.py` from the project root to `scripts/` and fixes the ruff E402 violation by placing all imports at the top of the file (removing the `sys.path.insert` hack).
- Adds `TestInitDb.test_redirect_url_index_exists` to `tests/test_db.py` asserting the index is present after `init_db()`.

## Performance evidence

Benchmark contributed by @Alm0stSurely in PR #138:

| | Without index | With index |
|---|---|---|
| 10,000 listings, 500 checks | ~0.45s | ~0.003s |
| **Speedup** | | **~150x** |

The query planner switches from a full table scan to `SEARCH listings USING INDEX idx_listings_redirect_url` after the index is created.

## Why this matters

`listing_exists_by_url()` is called once per candidate listing during ingest (the cross-source dedup step). At 500 listings/run with a 10k-row database, the unindexed path adds ~0.45s of wall time. The index eliminates that overhead entirely.

## Credit

This fix is based on the contribution in PR #138 by @Alm0stSurely. The `db.py` change is identical to their patch; this PR resolves the lint failure and adds the missing test so it can land cleanly.

## Test plan

- [x] `ruff check .` — clean
- [x] `pytest` — 592 passed
- [x] New test `test_redirect_url_index_exists` verifies index creation via `PRAGMA index_list(listings)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)