### PR TITLE
Feat: add settings_schema() to all LLM providers and job sources

### DIFF
--- a/job_sources/adzuna.py
+++ b/job_sources/adzuna.py
@@ -56,6 +56,32 @@ class AdzunaClient(JobSource):
     # JobSource interface
     # ------------------------------------------------------------------
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for Adzuna.
+
+        Returns:
+            Schema dict with ``display_name`` and credential ``fields``
+            for the Adzuna App ID and App Key.
+        """
+        return {
+            "display_name": "Adzuna",
+            "fields": [
+                {
+                    "name": "app_id",
+                    "label": "App ID",
+                    "type": "password",
+                    "required": True,
+                },
+                {
+                    "name": "app_key",
+                    "label": "App Key",
+                    "type": "password",
+                    "required": True,
+                },
+            ],
+        }
+
     def fetch_page(self, page: int) -> list[dict]:
         """Fetch a single page of raw Adzuna results.
 

--- a/job_sources/arbeitnow.py
+++ b/job_sources/arbeitnow.py
@@ -86,6 +86,20 @@ class ArbeitnowClient(JobSource):
     # JobSource interface
     # ------------------------------------------------------------------
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for Arbeitnow.
+
+        Arbeitnow requires no credentials — the public API is key-free.
+
+        Returns:
+            Schema dict with ``display_name`` and an empty ``fields`` list.
+        """
+        return {
+            "display_name": "Arbeitnow",
+            "fields": [],
+        }
+
     def fetch_page(self, page: int) -> list[dict]:
         """Fetch a single page of raw Arbeitnow listings.
 

--- a/job_sources/base.py
+++ b/job_sources/base.py
@@ -73,6 +73,26 @@ class JobSource(ABC):
         """
         ...
 
+    @classmethod
+    @abstractmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for this job source.
+
+        The returned dict describes the credentials and configuration fields
+        that the Settings UI should render for this source.
+
+        Returns:
+            Dict with exactly two keys:
+
+            * ``display_name`` — str, human-readable name shown in the UI.
+            * ``fields``       — list of field dicts.  Each field dict must
+              have: ``name`` (str), ``label`` (str), ``type`` (``"text"``
+              or ``"password"``), ``required`` (bool).  Sources that
+              require no credentials return an empty list so the UI can
+              render them as a status-only card.
+        """
+        ...
+
     def pages(self) -> Iterator[list[dict]]:
         """Yield normalised listing lists, one per page.
 

--- a/job_sources/himalayas.py
+++ b/job_sources/himalayas.py
@@ -114,6 +114,20 @@ class HimalayasClient(JobSource):
     # JobSource interface
     # ------------------------------------------------------------------
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for Himalayas.
+
+        Himalayas requires no credentials — the public API is key-free.
+
+        Returns:
+            Schema dict with ``display_name`` and an empty ``fields`` list.
+        """
+        return {
+            "display_name": "Himalayas",
+            "fields": [],
+        }
+
     def fetch_page(self, page: int) -> list[dict]:
         """Fetch a single page of raw Himalayas listings.
 

--- a/job_sources/remoteok.py
+++ b/job_sources/remoteok.py
@@ -104,6 +104,20 @@ class RemoteOKClient(JobSource):
     # JobSource interface
     # ------------------------------------------------------------------
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for Remote OK.
+
+        RemoteOK requires no credentials — the public API is key-free.
+
+        Returns:
+            Schema dict with ``display_name`` and an empty ``fields`` list.
+        """
+        return {
+            "display_name": "Remote OK",
+            "fields": [],
+        }
+
     def fetch_page(self, page: int) -> list[dict]:
         """Fetch all RemoteOK listings (the API has no pagination).
 

--- a/job_sources/remotive.py
+++ b/job_sources/remotive.py
@@ -112,6 +112,20 @@ class RemotiveClient(JobSource):
     # JobSource interface
     # ------------------------------------------------------------------
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for Remotive.
+
+        Remotive requires no credentials — the public API is key-free.
+
+        Returns:
+            Schema dict with ``display_name`` and an empty ``fields`` list.
+        """
+        return {
+            "display_name": "Remotive",
+            "fields": [],
+        }
+
     def fetch_page(self, page: int) -> list[dict]:
         """Fetch listings from the Remotive API.
 

--- a/job_sources/the_muse.py
+++ b/job_sources/the_muse.py
@@ -125,6 +125,21 @@ class TheMuseClient(JobSource):
     # JobSource interface
     # ------------------------------------------------------------------
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for The Muse.
+
+        The Muse's public API is key-free; an optional key exists for
+        higher rate limits but is not required for basic ingestion.
+
+        Returns:
+            Schema dict with ``display_name`` and an empty ``fields`` list.
+        """
+        return {
+            "display_name": "The Muse",
+            "fields": [],
+        }
+
     def fetch_page(self, page: int) -> list[dict]:
         """Fetch a single page of raw The Muse results.
 

--- a/job_sources/usajobs.py
+++ b/job_sources/usajobs.py
@@ -78,6 +78,35 @@ class USAJobsClient(JobSource):
     # JobSource interface
     # ------------------------------------------------------------------
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for USAJobs.
+
+        USAJobs requires an API key and a contact email (User-Agent) as
+        mandated by the USAJobs developer agreement.
+
+        Returns:
+            Schema dict with ``display_name`` and credential ``fields``
+            for the USAJobs API key and user-agent contact email.
+        """
+        return {
+            "display_name": "USAJobs",
+            "fields": [
+                {
+                    "name": "api_key",
+                    "label": "API Key",
+                    "type": "password",
+                    "required": True,
+                },
+                {
+                    "name": "user_agent",
+                    "label": "Contact Email (User-Agent)",
+                    "type": "text",
+                    "required": True,
+                },
+            ],
+        }
+
     def fetch_page(self, page: int) -> list[dict]:
         """Fetch a single page of raw USAJobs search results.
 

--- a/providers/anthropic_provider.py
+++ b/providers/anthropic_provider.py
@@ -75,6 +75,33 @@ class AnthropicProvider(LLMProvider):
     # LLMProvider interface
     # ------------------------------------------------------------------
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for Anthropic.
+
+        Returns:
+            Schema dict with ``display_name`` and ``fields`` for the
+            Anthropic API key and model ID.
+        """
+        return {
+            "display_name": "Anthropic",
+            "fields": [
+                {
+                    "name": "api_key",
+                    "label": "API Key",
+                    "type": "password",
+                    "required": True,
+                },
+                {
+                    "name": "model",
+                    "label": "Model ID",
+                    "type": "text",
+                    "required": True,
+                    "default": "claude-haiku-4-5-20251001",
+                },
+            ],
+        }
+
     @property
     def input_cost_per_mtok(self) -> float:
         """USD cost per million input tokens for the configured model."""

--- a/providers/base.py
+++ b/providers/base.py
@@ -62,3 +62,22 @@ class LLMProvider(ABC):
     def output_cost_per_mtok(self) -> float:
         """USD cost per million output tokens for the configured model."""
         ...
+
+    @classmethod
+    @abstractmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for this provider.
+
+        The returned dict describes the credentials and configuration fields
+        that the Settings UI should render for this provider.
+
+        Returns:
+            Dict with exactly two keys:
+
+            * ``display_name`` — str, human-readable name shown in the UI.
+            * ``fields``       — list of field dicts.  Each field dict must
+              have: ``name`` (str), ``label`` (str), ``type`` (``"text"``
+              or ``"password"``), ``required`` (bool).  Text fields may
+              also include a ``default`` (str) for pre-populated values.
+        """
+        ...

--- a/providers/gemini_provider.py
+++ b/providers/gemini_provider.py
@@ -69,6 +69,33 @@ class GeminiProvider(LLMProvider):
     # LLMProvider interface
     # ------------------------------------------------------------------
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for Gemini.
+
+        Returns:
+            Schema dict with ``display_name`` and ``fields`` for the
+            Google API key and model ID.
+        """
+        return {
+            "display_name": "Gemini",
+            "fields": [
+                {
+                    "name": "api_key",
+                    "label": "API Key",
+                    "type": "password",
+                    "required": True,
+                },
+                {
+                    "name": "model",
+                    "label": "Model ID",
+                    "type": "text",
+                    "required": True,
+                    "default": "gemini-1.5-flash",
+                },
+            ],
+        }
+
     @property
     def input_cost_per_mtok(self) -> float:
         """USD cost per million input tokens for the configured model."""

--- a/providers/openai_provider.py
+++ b/providers/openai_provider.py
@@ -69,6 +69,33 @@ class OpenAIProvider(LLMProvider):
     # LLMProvider interface
     # ------------------------------------------------------------------
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        """Return the settings schema for OpenAI.
+
+        Returns:
+            Schema dict with ``display_name`` and ``fields`` for the
+            OpenAI API key and model ID.
+        """
+        return {
+            "display_name": "OpenAI",
+            "fields": [
+                {
+                    "name": "api_key",
+                    "label": "API Key",
+                    "type": "password",
+                    "required": True,
+                },
+                {
+                    "name": "model",
+                    "label": "Model ID",
+                    "type": "text",
+                    "required": True,
+                    "default": "gpt-4o-mini",
+                },
+            ],
+        }
+
     @property
     def input_cost_per_mtok(self) -> float:
         """USD cost per million input tokens for the configured model."""

--- a/tests/test_ingest_run.py
+++ b/tests/test_ingest_run.py
@@ -108,6 +108,10 @@ class MockJobSource(JobSource):
         """Pass-through — the fixture data is already normalised."""
         return raw
 
+    @classmethod
+    def settings_schema(cls) -> dict:
+        return {"display_name": "Mock", "fields": []}
+
     def pages(self):
         """Yield a single page of normalised listings."""
         yield self._listings

--- a/tests/test_job_sources.py
+++ b/tests/test_job_sources.py
@@ -51,6 +51,9 @@ class TestJobSourceABC:
                 return 1
             def normalise(self, raw):
                 return {}
+            @classmethod
+            def settings_schema(cls):
+                return {"display_name": "Complete", "fields": []}
 
         # Should not raise.
         instance = Complete()

--- a/tests/test_job_sources_bugs.py
+++ b/tests/test_job_sources_bugs.py
@@ -216,6 +216,10 @@ class TestAbcDefaultPages:
             def normalise(self, raw):
                 return raw
 
+            @classmethod
+            def settings_schema(cls):
+                return {"display_name": "Minimal", "fields": []}
+
         src = MinimalSource()
         pages = list(src.pages())
         assert len(pages) == 1  # page 2 returns empty → stops early

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -1,0 +1,312 @@
+"""
+tests/test_settings_schema.py — Tests for settings_schema() classmethods.
+
+Verifies that every LLM provider and job source class exposes a
+``settings_schema()`` classmethod returning a well-formed dict, and that the
+schemas are reachable via the existing registries (``_PROVIDER_CLASS_MAP`` and
+``SOURCES``).
+
+Covered cases
+-------------
+* Every LLM provider returns a dict with ``display_name`` (str) and
+  ``fields`` (list).
+* Every field in an LLM provider schema has the mandatory keys:
+  ``name``, ``label``, ``type``, ``required``.
+* Every field ``type`` is one of ``{"text", "password"}``.
+* LLM providers with a ``model`` field expose a sensible ``default`` value.
+* Every job source returns a dict with ``display_name`` (str) and
+  ``fields`` (list).
+* Sources with no credentials return ``fields: []``.
+* Sources with credentials have all mandatory field keys.
+* Schemas are reachable via the registries.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from providers import AnthropicProvider, OpenAIProvider, GeminiProvider
+from providers import _PROVIDER_CLASS_MAP
+from job_sources import SOURCES
+from job_sources.adzuna import AdzunaClient
+from job_sources.arbeitnow import ArbeitnowClient
+from job_sources.himalayas import HimalayasClient
+from job_sources.remoteok import RemoteOKClient
+from job_sources.usajobs import USAJobsClient
+from job_sources.the_muse import TheMuseClient
+from job_sources.remotive import RemotiveClient
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_VALID_FIELD_TYPES = {"text", "password"}
+_MANDATORY_FIELD_KEYS = {"name", "label", "type", "required"}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_schema_shape(schema: dict, context: str) -> None:
+    """Assert top-level ``display_name`` and ``fields`` keys are well-formed."""
+    assert isinstance(schema, dict), f"{context}: schema must be a dict"
+    assert "display_name" in schema, f"{context}: missing 'display_name'"
+    assert isinstance(schema["display_name"], str), (
+        f"{context}: 'display_name' must be a str"
+    )
+    assert "fields" in schema, f"{context}: missing 'fields'"
+    assert isinstance(schema["fields"], list), f"{context}: 'fields' must be a list"
+
+
+def _assert_field_shape(field: dict, context: str) -> None:
+    """Assert a single field dict has all mandatory keys and a valid type."""
+    missing = _MANDATORY_FIELD_KEYS - set(field)
+    assert not missing, f"{context}: field missing keys {missing}: {field!r}"
+    assert field["type"] in _VALID_FIELD_TYPES, (
+        f"{context}: field type {field['type']!r} not in {_VALID_FIELD_TYPES}"
+    )
+    assert isinstance(field["required"], bool), (
+        f"{context}: 'required' must be bool, got {type(field['required'])!r}"
+    )
+
+
+# ===========================================================================
+# LLM Providers
+# ===========================================================================
+
+
+class TestAnthropicProviderSchema:
+    def test_returns_well_formed_schema(self):
+        schema = AnthropicProvider.settings_schema()
+        _assert_schema_shape(schema, "AnthropicProvider")
+
+    def test_display_name(self):
+        assert AnthropicProvider.settings_schema()["display_name"] == "Anthropic"
+
+    def test_all_fields_have_mandatory_keys(self):
+        for field in AnthropicProvider.settings_schema()["fields"]:
+            _assert_field_shape(field, "AnthropicProvider")
+
+    def test_has_api_key_field(self):
+        fields_by_name = {f["name"]: f for f in AnthropicProvider.settings_schema()["fields"]}
+        assert "api_key" in fields_by_name
+        assert fields_by_name["api_key"]["type"] == "password"
+        assert fields_by_name["api_key"]["required"] is True
+
+    def test_has_model_field_with_default(self):
+        fields_by_name = {f["name"]: f for f in AnthropicProvider.settings_schema()["fields"]}
+        assert "model" in fields_by_name
+        assert fields_by_name["model"]["type"] == "text"
+        assert fields_by_name["model"]["required"] is True
+        assert "default" in fields_by_name["model"]
+        assert isinstance(fields_by_name["model"]["default"], str)
+        assert fields_by_name["model"]["default"]  # non-empty
+
+
+class TestOpenAIProviderSchema:
+    def test_returns_well_formed_schema(self):
+        schema = OpenAIProvider.settings_schema()
+        _assert_schema_shape(schema, "OpenAIProvider")
+
+    def test_display_name(self):
+        assert OpenAIProvider.settings_schema()["display_name"] == "OpenAI"
+
+    def test_all_fields_have_mandatory_keys(self):
+        for field in OpenAIProvider.settings_schema()["fields"]:
+            _assert_field_shape(field, "OpenAIProvider")
+
+    def test_has_api_key_field(self):
+        fields_by_name = {f["name"]: f for f in OpenAIProvider.settings_schema()["fields"]}
+        assert "api_key" in fields_by_name
+        assert fields_by_name["api_key"]["type"] == "password"
+        assert fields_by_name["api_key"]["required"] is True
+
+    def test_has_model_field_with_default(self):
+        fields_by_name = {f["name"]: f for f in OpenAIProvider.settings_schema()["fields"]}
+        assert "model" in fields_by_name
+        assert fields_by_name["model"]["type"] == "text"
+        assert fields_by_name["model"]["required"] is True
+        assert "default" in fields_by_name["model"]
+        assert isinstance(fields_by_name["model"]["default"], str)
+        assert fields_by_name["model"]["default"]
+
+
+class TestGeminiProviderSchema:
+    def test_returns_well_formed_schema(self):
+        schema = GeminiProvider.settings_schema()
+        _assert_schema_shape(schema, "GeminiProvider")
+
+    def test_display_name(self):
+        assert GeminiProvider.settings_schema()["display_name"] == "Gemini"
+
+    def test_all_fields_have_mandatory_keys(self):
+        for field in GeminiProvider.settings_schema()["fields"]:
+            _assert_field_shape(field, "GeminiProvider")
+
+    def test_has_api_key_field(self):
+        fields_by_name = {f["name"]: f for f in GeminiProvider.settings_schema()["fields"]}
+        assert "api_key" in fields_by_name
+        assert fields_by_name["api_key"]["type"] == "password"
+        assert fields_by_name["api_key"]["required"] is True
+
+    def test_has_model_field_with_default(self):
+        fields_by_name = {f["name"]: f for f in GeminiProvider.settings_schema()["fields"]}
+        assert "model" in fields_by_name
+        assert fields_by_name["model"]["type"] == "text"
+        assert fields_by_name["model"]["required"] is True
+        assert "default" in fields_by_name["model"]
+        assert isinstance(fields_by_name["model"]["default"], str)
+        assert fields_by_name["model"]["default"]
+
+
+class TestProviderRegistryAccess:
+    """settings_schema() must be reachable via _PROVIDER_CLASS_MAP."""
+
+    def test_anthropic_via_registry(self):
+        schema = _PROVIDER_CLASS_MAP["anthropic"].settings_schema()
+        _assert_schema_shape(schema, "_PROVIDER_CLASS_MAP['anthropic']")
+
+    def test_openai_via_registry(self):
+        schema = _PROVIDER_CLASS_MAP["openai"].settings_schema()
+        _assert_schema_shape(schema, "_PROVIDER_CLASS_MAP['openai']")
+
+    def test_gemini_via_registry(self):
+        schema = _PROVIDER_CLASS_MAP["gemini"].settings_schema()
+        _assert_schema_shape(schema, "_PROVIDER_CLASS_MAP['gemini']")
+
+    def test_all_registered_providers_have_schema(self):
+        for key, cls in _PROVIDER_CLASS_MAP.items():
+            schema = cls.settings_schema()
+            _assert_schema_shape(schema, f"_PROVIDER_CLASS_MAP[{key!r}]")
+
+
+# ===========================================================================
+# Job Sources
+# ===========================================================================
+
+
+class TestAdzunaSourceSchema:
+    def test_returns_well_formed_schema(self):
+        schema = AdzunaClient.settings_schema()
+        _assert_schema_shape(schema, "AdzunaClient")
+
+    def test_display_name(self):
+        assert AdzunaClient.settings_schema()["display_name"] == "Adzuna"
+
+    def test_all_fields_have_mandatory_keys(self):
+        for field in AdzunaClient.settings_schema()["fields"]:
+            _assert_field_shape(field, "AdzunaClient")
+
+    def test_has_app_id_field(self):
+        fields_by_name = {f["name"]: f for f in AdzunaClient.settings_schema()["fields"]}
+        assert "app_id" in fields_by_name
+        assert fields_by_name["app_id"]["type"] == "password"
+        assert fields_by_name["app_id"]["required"] is True
+
+    def test_has_app_key_field(self):
+        fields_by_name = {f["name"]: f for f in AdzunaClient.settings_schema()["fields"]}
+        assert "app_key" in fields_by_name
+        assert fields_by_name["app_key"]["type"] == "password"
+        assert fields_by_name["app_key"]["required"] is True
+
+
+class TestUSAJobsSourceSchema:
+    def test_returns_well_formed_schema(self):
+        schema = USAJobsClient.settings_schema()
+        _assert_schema_shape(schema, "USAJobsClient")
+
+    def test_display_name(self):
+        assert USAJobsClient.settings_schema()["display_name"] == "USAJobs"
+
+    def test_all_fields_have_mandatory_keys(self):
+        for field in USAJobsClient.settings_schema()["fields"]:
+            _assert_field_shape(field, "USAJobsClient")
+
+    def test_has_api_key_field(self):
+        fields_by_name = {f["name"]: f for f in USAJobsClient.settings_schema()["fields"]}
+        assert "api_key" in fields_by_name
+        assert fields_by_name["api_key"]["type"] == "password"
+        assert fields_by_name["api_key"]["required"] is True
+
+    def test_has_user_agent_field(self):
+        fields_by_name = {f["name"]: f for f in USAJobsClient.settings_schema()["fields"]}
+        assert "user_agent" in fields_by_name
+        assert fields_by_name["user_agent"]["required"] is True
+
+
+class TestNoCredentialSources:
+    """Sources with no credentials must return an empty fields list."""
+
+    @pytest.mark.parametrize("cls,expected_name", [
+        (ArbeitnowClient, "Arbeitnow"),
+        (HimalayasClient, "Himalayas"),
+        (RemoteOKClient, "Remote OK"),
+        (TheMuseClient, "The Muse"),
+        (RemotiveClient, "Remotive"),
+    ])
+    def test_returns_well_formed_schema(self, cls, expected_name):
+        schema = cls.settings_schema()
+        _assert_schema_shape(schema, cls.__name__)
+
+    @pytest.mark.parametrize("cls,expected_name", [
+        (ArbeitnowClient, "Arbeitnow"),
+        (HimalayasClient, "Himalayas"),
+        (RemoteOKClient, "Remote OK"),
+        (TheMuseClient, "The Muse"),
+        (RemotiveClient, "Remotive"),
+    ])
+    def test_display_name(self, cls, expected_name):
+        assert cls.settings_schema()["display_name"] == expected_name
+
+    @pytest.mark.parametrize("cls,expected_name", [
+        (ArbeitnowClient, "Arbeitnow"),
+        (HimalayasClient, "Himalayas"),
+        (RemoteOKClient, "Remote OK"),
+        (TheMuseClient, "The Muse"),
+        (RemotiveClient, "Remotive"),
+    ])
+    def test_empty_fields(self, cls, expected_name):
+        assert cls.settings_schema()["fields"] == []
+
+
+class TestSourceRegistryAccess:
+    """settings_schema() must be reachable via the SOURCES registry."""
+
+    def test_adzuna_via_registry(self):
+        schema = SOURCES["adzuna"].settings_schema()
+        _assert_schema_shape(schema, "SOURCES['adzuna']")
+
+    def test_arbeitnow_via_registry(self):
+        schema = SOURCES["arbeitnow"].settings_schema()
+        _assert_schema_shape(schema, "SOURCES['arbeitnow']")
+
+    def test_himalayas_via_registry(self):
+        schema = SOURCES["himalayas"].settings_schema()
+        _assert_schema_shape(schema, "SOURCES['himalayas']")
+
+    def test_remoteok_via_registry(self):
+        schema = SOURCES["remoteok"].settings_schema()
+        _assert_schema_shape(schema, "SOURCES['remoteok']")
+
+    def test_usajobs_via_registry(self):
+        schema = SOURCES["usajobs"].settings_schema()
+        _assert_schema_shape(schema, "SOURCES['usajobs']")
+
+    def test_the_muse_via_registry(self):
+        schema = SOURCES["the_muse"].settings_schema()
+        _assert_schema_shape(schema, "SOURCES['the_muse']")
+
+    def test_remotive_via_registry(self):
+        schema = SOURCES["remotive"].settings_schema()
+        _assert_schema_shape(schema, "SOURCES['remotive']")
+
+    def test_all_registered_sources_have_schema(self):
+        for key, cls in SOURCES.items():
+            schema = cls.settings_schema()
+            _assert_schema_shape(schema, f"SOURCES[{key!r}]")


### PR DESCRIPTION
## Summary

Adds `settings_schema()` as an abstract classmethod to `LLMProvider` and `JobSource` base classes, with concrete implementations on all 10 provider/source classes. The settings route will loop these in the next issue (#149) to render the form dynamically — no hardcoded provider blocks.

## What changed

**Base classes** — `settings_schema()` declared as `@classmethod @abstractmethod` on both `providers/base.py` and `job_sources/base.py`. Any concrete subclass missing an implementation now raises `TypeError` at instantiation time.

**LLM providers** (3):
- `AnthropicProvider` — display "Anthropic", fields: `api_key` (password), `model` (text, default `claude-haiku-4-5-20251001`)
- `OpenAIProvider` — display "OpenAI", fields: `api_key` (password), `model` (text, default `gpt-4o-mini`)
- `GeminiProvider` — display "Gemini", fields: `api_key` (password), `model` (text, default `gemini-1.5-flash`)

**Job sources** (7):
- `AdzunaClient` — `app_id` + `app_key` (both password)
- `USAJobsClient` — `api_key` (password) + `user_agent` (text) matching the two credentials the constructor validates
- `ArbeitnowClient`, `HimalayasClient`, `RemoteOKClient`, `TheMuseClient`, `RemotiveClient` — `fields: []` (no credentials required)

**Test stubs** — existing test mock classes that subclass `JobSource` gained minimal `settings_schema()` implementations to satisfy the new abstract contract.

## Tests

52 new tests in `tests/test_settings_schema.py` covering: schema shape, mandatory field keys, valid field types, registry reachability via `_PROVIDER_CLASS_MAP` and `SOURCES`, and empty-fields enforcement for no-credential sources.

- 592 total passing, 1 warning (existing google-genai SDK deprecation)

closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)