### PR TITLE
Fix: remove bare push trigger — CI was running twice on every PR push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Problem

`ci.yml` had two triggers:
```yaml
on:
  push:            # fires on every push to any branch
  pull_request:
    branches: [main]
```

When a commit is pushed to an open PR branch, both events fire simultaneously → two identical CI runs per push.

## Fix

Remove the bare `push` trigger. The `pull_request` event (which fires on `opened`, `synchronize`, and `reopened` by default) covers all the cases we need.

## Does CI still run on PR updates?

Yes — `pull_request: synchronize` fires automatically on every new commit pushed to a PR branch. No coverage lost.

closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)