### PR TITLE
Fix: restore post-merge CI trigger for Deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Adds `push: branches: [main]` back to `ci.yml` — 2 lines, 1 file

## Root cause

`deploy.yml` triggers via `workflow_run` on "CI" with `branches: [main]`, meaning it only fires when CI runs on `main` directly. PR #158 removed the bare `push:` trigger to fix CI double-running on PRs, but that was also what ran CI on `main` after each merge — the event Deploy depends on. Without it, Deploy never fires.

## Why this doesn't re-introduce the double-run

The original problem was a bare `push:` (no filter) firing on every branch simultaneously with `pull_request`. Scoping `push` to `branches: [main]` means it only fires after a commit lands on `main` (i.e. post-merge). PRs still get exactly one CI run from `pull_request`.

closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)