### PR TITLE
Fix: normalize Arbeitnow contract_time to canonical full_time value

### DIFF
--- a/job_sources/arbeitnow.py
+++ b/job_sources/arbeitnow.py
@@ -23,6 +23,17 @@ logger = logging.getLogger("ingest.arbeitnow")
 
 _BASE_URL = "https://www.arbeitnow.com/api/job-board-api"
 
+# Arbeitnow uses inconsistent strings for full-time employment — some in English,
+# some in German.  This map normalises them to the canonical "full_time" value so
+# the prefilter's contract_time check can match them.  Lookup is case-insensitive.
+# Unmapped values are passed through unchanged so genuinely part-time or contract
+# roles are still rejected by the prefilter.
+_CONTRACT_TIME_MAP: dict[str, str] = {
+    "full-time permanent": "full_time",
+    "berufserfahren": "full_time",        # German: "experienced professional"
+    "professional / experienced": "full_time",
+}
+
 
 def _strip_html(html: str) -> str:
     """Remove HTML tags and return plain text.
@@ -217,8 +228,15 @@ class ArbeitnowClient(JobSource):
             location = location_raw
 
         # contract_time: first element of job_types list, or None.
+        # Normalise non-standard Arbeitnow strings to the canonical value so that
+        # the prefilter's contract_time check can match full-time roles reliably.
         job_types: list = raw.get("job_types") or []
-        contract_time: str | None = job_types[0] if job_types else None
+        raw_contract_time: str | None = job_types[0] if job_types else None
+        contract_time: str | None = (
+            _CONTRACT_TIME_MAP.get(raw_contract_time.lower(), raw_contract_time)
+            if raw_contract_time is not None
+            else None
+        )
 
         # Strip HTML from description.
         raw_description: str = raw.get("description", "") or ""

--- a/tests/test_job_sources_arbeitnow.py
+++ b/tests/test_job_sources_arbeitnow.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from job_sources import SOURCES, ArbeitnowClient, JobSource
-from job_sources.arbeitnow import _strip_html, _unix_to_iso
+from job_sources.arbeitnow import _CONTRACT_TIME_MAP, _strip_html, _unix_to_iso
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +230,68 @@ class TestArbeitnowClientNormalise:
         result = client.normalise(_RAW_LISTING)
 
         assert required_keys.issubset(result.keys())
+
+    # contract_time normalisation (issue #174)
+    def test_full_time_permanent_normalised(self):
+        """'Full-time permanent' is normalised to 'full_time'."""
+        client = _client()
+        raw = {**_RAW_LISTING, "job_types": ["Full-time permanent"]}
+        assert client.normalise(raw)["contract_time"] == "full_time"
+
+    def test_berufserfahren_normalised(self):
+        """German 'berufserfahren' is normalised to 'full_time'."""
+        client = _client()
+        raw = {**_RAW_LISTING, "job_types": ["berufserfahren"]}
+        assert client.normalise(raw)["contract_time"] == "full_time"
+
+    def test_professional_experienced_normalised(self):
+        """'professional / experienced' is normalised to 'full_time'."""
+        client = _client()
+        raw = {**_RAW_LISTING, "job_types": ["professional / experienced"]}
+        assert client.normalise(raw)["contract_time"] == "full_time"
+
+    def test_normalisation_is_case_insensitive(self):
+        """Mapping lookup is case-insensitive (e.g. 'BERUFSERFAHREN' still maps)."""
+        client = _client()
+        raw = {**_RAW_LISTING, "job_types": ["BERUFSERFAHREN"]}
+        assert client.normalise(raw)["contract_time"] == "full_time"
+
+    def test_canonical_full_time_passes_through_unchanged(self):
+        """An already-canonical 'full_time' value is not altered."""
+        client = _client()
+        raw = {**_RAW_LISTING, "job_types": ["full_time"]}
+        assert client.normalise(raw)["contract_time"] == "full_time"
+
+    def test_unmapped_value_passes_through_unchanged(self):
+        """A value not in the map (e.g. 'part_time') is returned as-is."""
+        client = _client()
+        raw = {**_RAW_LISTING, "job_types": ["part_time"]}
+        assert client.normalise(raw)["contract_time"] == "part_time"
+
+    def test_none_contract_time_unaffected_by_normalisation(self):
+        """None contract_time (empty job_types) is preserved as None."""
+        client = _client()
+        raw = {**_RAW_LISTING, "job_types": []}
+        assert client.normalise(raw)["contract_time"] is None
+
+
+# ---------------------------------------------------------------------------
+# _CONTRACT_TIME_MAP constant
+# ---------------------------------------------------------------------------
+
+class TestContractTimeMap:
+    def test_map_contains_all_known_nonstandard_values(self):
+        """All documented non-standard Arbeitnow strings are in the map."""
+        expected_keys = {
+            "full-time permanent",
+            "berufserfahren",
+            "professional / experienced",
+        }
+        assert expected_keys == set(_CONTRACT_TIME_MAP.keys())
+
+    def test_all_map_values_are_full_time(self):
+        """Every entry in the map normalises to 'full_time'."""
+        assert all(v == "full_time" for v in _CONTRACT_TIME_MAP.values())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Valid full-time Arbeitnow listings were being dropped by the prefilter because `contract_time` values weren't normalized to the canonical `"full_time"` string the prefilter expects.

## Root cause

`arbeitnow.py` was passing `job_types[0]` directly as `contract_time` without translation. Arbeitnow uses at least three non-standard strings for full-time roles:
- `"Full-time permanent"`
- `"berufserfahren"` (German: "experienced professional")
- `"professional / experienced"`

## Fix

Added a module-level `_CONTRACT_TIME_MAP` dict in `job_sources/arbeitnow.py` with a case-insensitive `.get()` lookup in `normalise()`. Unmapped values fall through unchanged so genuinely part-time/contract roles are still filtered correctly.

Closes #174

## Test plan

- [ ] 9 new unit tests covering all known non-standard values, case-insensitivity, pass-through for unmapped values, and `None` preservation
- [ ] All 747 tests pass (9 new tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)