### PR TITLE
Chore: update claude-code-action workflows to v1.4.1

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.4.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.4.1
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/tag-claude.yml
+++ b/.github/workflows/tag-claude.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   respond:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.4.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.4.1
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
Bumps `cbeaulieu-gt/github-actions` version pin from `v1.4.0` → `v1.4.1` in two workflow files:
- `.github/workflows/claude-pr-review.yml`
- `.github/workflows/tag-claude.yml`

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)