### PR TITLE
chore: update claude-code-action workflows to v1.4.3

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.4.2
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.4.3
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/tag-claude.yml
+++ b/.github/workflows/tag-claude.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   respond:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.4.2
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.4.3
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary

Bumps `cbeaulieu-gt/github-actions` version pin from `v1.4.2` → `v1.4.3`.

## Files changed

- `.github/workflows/claude-pr-review.yml`
- `.github/workflows/tag-claude.yml`

closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)