### PR TITLE
fix(ingest): rescore summary to logger, deduplicate get_all_scored

### DIFF
--- a/db.py
+++ b/db.py
@@ -628,11 +628,26 @@ def get_bookmarks(db_path: str = _DEFAULT_DB_PATH) -> list[dict]:
 
 
 def get_all_scored(db_path: str = _DEFAULT_DB_PATH) -> list[dict]:
-    """Return all listings that have been scored (seen = 1), ordered by fetched_at DESC."""
+    """Return all listings that have been scored (seen = 1), ordered by fetched_at DESC.
+
+    Uses a subquery to pick the row with the highest id per (source, source_id)
+    pair so that any accidental duplicate rows (e.g. from an imperfect migration)
+    are collapsed to a single entry before the caller iterates them.
+    """
     conn = get_connection(db_path)
     try:
         rows = conn.execute(
-            "SELECT * FROM listings WHERE seen = 1 ORDER BY fetched_at DESC"
+            """
+            SELECT * FROM listings
+            WHERE seen = 1
+              AND id IN (
+                  SELECT MAX(id)
+                  FROM listings
+                  WHERE seen = 1
+                  GROUP BY source, source_id
+              )
+            ORDER BY fetched_at DESC
+            """
         ).fetchall()
         return [_deserialise_row(r) for r in rows]
     finally:

--- a/ingest.py
+++ b/ingest.py
@@ -577,7 +577,7 @@ def run(
         logger.warning(
             "No job sources are enabled. Enable at least one source in Settings > Sources."
         )
-        print("Run complete: 0 fetched | no sources enabled")
+        logger.info("Run complete: 0 fetched | no sources enabled")
         return
 
     chain = build_provider_chain(providers)
@@ -784,20 +784,22 @@ def run(
 
     total_tokens = total_tokens_input + total_tokens_output
     run_cost = sum(b["cost"] for b in provider_costs.values())
-    print(
-        f"Run complete: {len(sources)} source(s) | {fetched} fetched | {prefiltered} pre-filtered | "
-        f"{deduped} dupes skipped | {scored} scored ({score_failed} failed) | "
-        f"{scraped_fallback} scrape fallbacks | "
-        f"~{total_tokens:,} tok | ~${run_cost:.4f}"
+    logger.info(
+        "Run complete: %d source(s) | %d fetched | %d pre-filtered | "
+        "%d dupes skipped | %d scored (%d failed) | "
+        "%d scrape fallbacks | ~%s tok | ~$%.4f",
+        len(sources), fetched, prefiltered,
+        deduped, scored, score_failed,
+        scraped_fallback, f"{total_tokens:,}", run_cost,
     )
     if len(provider_costs) > 1:
         breakdown = " | ".join(
             f"{name}: ~{b['input'] + b['output']:,} tok ~${b['cost']:.4f}"
             for name, b in provider_costs.items()
         )
-        print(f"  Cost breakdown: {breakdown}")
+        logger.info("  Cost breakdown: %s", breakdown)
     if source_fetch_counts:
-        print("  Sources: " + " | ".join(f"{src}: {cnt}" for src, cnt in source_fetch_counts.items()))
+        logger.info("  Sources: %s", " | ".join(f"{src}: {cnt}" for src, cnt in source_fetch_counts.items()))
     logger.info("=" * 60)
     logger.info("INGEST RUN COMPLETE")
     logger.info("=" * 60)
@@ -845,7 +847,7 @@ def rescore(
 
     listings = db.get_all_scored(db_path=_DB_PATH)
     if not listings:
-        print("No scored listings to rescore.")
+        logger.info("No scored listings to rescore.")
         return
 
     total = len(listings)
@@ -899,16 +901,16 @@ def rescore(
 
     total_tokens = tokens_input + tokens_output
     cost = sum(b["cost"] for b in provider_costs.values())
-    print(
-        f"Rescore complete: {total} listings | {rescored} rescored ({failed} failed) | "
-        f"~{total_tokens:,} tok | ~${cost:.4f}"
+    logger.info(
+        "Rescore complete: %d listings | %d rescored (%d failed) | ~%s tok | ~$%.4f",
+        total, rescored, failed, f"{total_tokens:,}", cost,
     )
     if len(provider_costs) > 1:
         breakdown = " | ".join(
             f"{name}: ~{b['input'] + b['output']:,} tok ~${b['cost']:.4f}"
             for name, b in provider_costs.items()
         )
-        print(f"  Cost breakdown: {breakdown}")
+        logger.info("  Cost breakdown: %s", breakdown)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingest_run.py
+++ b/tests/test_ingest_run.py
@@ -264,8 +264,9 @@ class TestIngestRunHappyPath:
         assert "Senior Python Engineer" in titles
         assert "Backend Developer" in titles
 
-    def test_summary_line_matches_app_regex(self, tmp_path, capsys):
-        """The printed summary line matches ``app._INGEST_SUMMARY_RE``."""
+    def test_summary_line_matches_app_regex(self, tmp_path, caplog):
+        """The logged summary line matches ``app._INGEST_SUMMARY_RE``."""
+        import logging
         db_path = str(tmp_path / "jobs.db")
         config_path = _make_temp_config(tmp_path)
         profile_path = _make_temp_profile(tmp_path)
@@ -280,6 +281,7 @@ class TestIngestRunHappyPath:
             patch("ingest.scrape_description", return_value=("Full job description text here.", True)),
             patch("ingest.score_listing_with_fallback", return_value=_fixed_score_result()),
             patch.object(ingest, "_DB_PATH", db_path),
+            caplog.at_level(logging.INFO, logger="ingest"),
         ):
             ingest.run(
                 config_path=config_path,
@@ -287,13 +289,12 @@ class TestIngestRunHappyPath:
                 keys_path=keys_path,
             )
 
-        captured = capsys.readouterr()
-        stdout = captured.out
+        log_text = caplog.text
 
-        m = _INGEST_SUMMARY_RE.search(stdout)
+        m = _INGEST_SUMMARY_RE.search(log_text)
         assert m is not None, (
             f"Summary line did not match _INGEST_SUMMARY_RE.\n"
-            f"Printed output:\n{stdout}"
+            f"Log output:\n{log_text}"
         )
 
         fetched = int(m.group(1))
@@ -411,8 +412,9 @@ class TestIngestRunScoringFailure:
         feed = db.get_feed(threshold=6.0, db_path=db_path)
         assert feed == [], "Score-failed listing must not appear in the feed"
 
-    def test_score_failure_summary_reports_one_failed(self, tmp_path, capsys):
+    def test_score_failure_summary_reports_one_failed(self, tmp_path, caplog):
         """The summary line records score_failed=1 when one listing fails scoring."""
+        import logging
         db_path = str(tmp_path / "jobs.db")
         config_path = _make_temp_config(tmp_path)
         profile_path = _make_temp_profile(tmp_path)
@@ -427,6 +429,7 @@ class TestIngestRunScoringFailure:
             patch("ingest.scrape_description", return_value=("Full job description text here.", True)),
             patch("ingest.score_listing_with_fallback", return_value=None),
             patch.object(ingest, "_DB_PATH", db_path),
+            caplog.at_level(logging.INFO, logger="ingest"),
         ):
             ingest.run(
                 config_path=config_path,
@@ -434,13 +437,12 @@ class TestIngestRunScoringFailure:
                 keys_path=keys_path,
             )
 
-        captured = capsys.readouterr()
-        stdout = captured.out
+        log_text = caplog.text
 
-        m = _INGEST_SUMMARY_RE.search(stdout)
+        m = _INGEST_SUMMARY_RE.search(log_text)
         assert m is not None, (
             f"Summary line did not match _INGEST_SUMMARY_RE.\n"
-            f"Printed output:\n{stdout}"
+            f"Log output:\n{log_text}"
         )
 
         score_failed = int(m.group(3))
@@ -480,8 +482,9 @@ class TestIngestRunDedup:
 
         assert count == 2, f"Expected 2 rows (no dupes), got {count}"
 
-    def test_duplicate_reflected_in_summary(self, tmp_path, capsys):
+    def test_duplicate_reflected_in_summary(self, tmp_path, caplog):
         """Second run reports 2 dupes skipped in its summary line."""
+        import logging
         db_path = str(tmp_path / "jobs.db")
         config_path = _make_temp_config(tmp_path)
         profile_path = _make_temp_profile(tmp_path)
@@ -505,16 +508,16 @@ class TestIngestRunDedup:
             patch("ingest.scrape_description", return_value=("Full job description text here.", True)),
             patch("ingest.score_listing_with_fallback", return_value=_fixed_score_result()),
             patch.object(ingest, "_DB_PATH", db_path),
+            caplog.at_level(logging.INFO, logger="ingest"),
         ):
             ingest.run(config_path=config_path, profile_path=profile_path, keys_path=keys_path)
-            capsys.readouterr()  # Discard first run output.
+            caplog.clear()  # Discard first run log output.
             ingest.run(config_path=config_path, profile_path=profile_path, keys_path=keys_path)
 
-        captured = capsys.readouterr()
-        stdout = captured.out
+        log_text = caplog.text
 
-        m = _dupe_summary_re.search(stdout)
-        assert m is not None, f"Expected dupe summary in output:\n{stdout}"
+        m = _dupe_summary_re.search(log_text)
+        assert m is not None, f"Expected dupe summary in log output:\n{log_text}"
 
         dupes = int(m.group(2))
         assert dupes == 2, f"Expected 2 dupes skipped, got {dupes}"


### PR DESCRIPTION
## Summary

Fixes two bugs in `--rescore` runs reported in #199.

## Bug 1 — Rescore summary never appeared in log file

**Root cause:** `rescore()` and `run()` used `print()` for end-of-run summary lines. `print()` writes to stdout; the file logger attached by `_configure_file_logging()` only captures `logging` hierarchy calls. Summary lines were invisible in log files.

**Fix:** Replaced all `print()` calls in both `rescore()` and `run()` (including early-return paths) with `logger.info()`. Three tests in `test_ingest_run.py` updated to use `caplog` instead of `capsys` to match.

## Bug 2 — Duplicate listings being rescored

**Root cause:** `get_all_scored()` ran `SELECT * FROM listings WHERE seen = 1` with no deduplication. The `UNIQUE(source, source_id)` constraint prevents new duplicates, but rows inserted before the constraint existed (via the Path C migration) could still be present and cause a listing to be rescored twice.

**Fix:** Added a `MAX(id)` subquery to `get_all_scored()` to deduplicate by `(source, source_id)`, keeping the most recently inserted row per pair. Return type and all callers unchanged.

## Files changed

- `ingest.py` — `print()` → `logger.info()` in `run()` and `rescore()`
- `db.py` — `get_all_scored()` deduplicates via `MAX(id)` subquery
- `tests/test_ingest_run.py` — updated 3 tests to use `caplog` instead of `capsys`

closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)