### PR TITLE
fix: swap toggle pill and credential hint for vertical alignment

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -212,6 +212,9 @@ All buttons extend `.btn` (base). Add a modifier class for semantic variants.
 Used for binary on/off controls (e.g. source enabled). Pure CSS — no JS required.
 
 ```html
+{% if toggle_disabled %}
+  <span class="toggle-hint">Add credentials to enable</span>
+{% endif %}
 <label class="source-toggle">
   <input
     type="checkbox"
@@ -224,9 +227,6 @@ Used for binary on/off controls (e.g. source enabled). Pure CSS — no JS requir
     <span class="source-toggle-knob"></span>
   </span>
 </label>
-{% if toggle_disabled %}
-  <span class="toggle-hint">Add credentials to enable</span>
-{% endif %}
 ```
 
 | Class | Element | Notes |

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -365,6 +365,9 @@
             {% else %}
               <span class="key-status configured">&#9679; no credentials required</span>
             {% endif %}
+            {% if toggle_disabled %}
+              <span class="toggle-hint">Add credentials to enable</span>
+            {% endif %}
             <label class="source-toggle">
               <input
                 type="checkbox"
@@ -377,9 +380,6 @@
                 <span class="source-toggle-knob"></span>
               </span>
             </label>
-            {% if toggle_disabled %}
-              <span class="toggle-hint">Add credentials to enable</span>
-            {% endif %}
           </div>
 
           {% for field in schema.fields %}


### PR DESCRIPTION
## Summary
- Moves the "Add credentials to enable" hint before the toggle pill in `.provider-header` so the pill is always the last (rightmost) flex child
- Also updates the Toggle Switch code example in `docs/STYLE_GUIDE.md` to reflect the correct element order

## Why
Previously the hint appeared after the pill on credential-required cards, causing `margin-left: auto` to anchor at a different position than on no-credential cards — breaking vertical alignment across all source toggle pills.

## Test plan
- [ ] Open Settings > Sources — confirm toggle pills are vertically aligned across all cards
- [ ] Confirm "Add credentials to enable" hint still appears on credential-required cards

closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)