### PR TITLE
feat: add description blurb to each job source card

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -206,6 +206,7 @@ All buttons extend `.btn` (base). Add a modifier class for semantic variants.
 | `.filter-select` | `<select>` | Filter bar dropdown; custom SVG arrow |
 | `.filter-toggle` | `<label>` | Checkbox label wrapper in filter bar |
 | `.provider-home-link` | `<a>` | External link icon (↗) placed next to provider names on the Settings → Job Sources tab; `font-size: 0.8rem`, `var(--text-muted)` at rest, `var(--text-accent)` on hover, `transition: color 0.15s` |
+| `.source-description` | `<p>` | Short blurb below `.provider-header` on each source card; `--font-body` 0.82rem, `--text-muted`, `line-height: 1.5`; rendered only when `schema.description` is set |
 
 ### Toggle Switch
 

--- a/job_sources/adzuna.py
+++ b/job_sources/adzuna.py
@@ -66,6 +66,7 @@ class AdzunaClient(JobSource):
         """
         return {
             "display_name": "Adzuna",
+            "description": "Global job aggregator with broad coverage across industries and countries. Requires a free API key from adzuna.com. Best for high-volume searches in supported regions.",
             "home_url": "https://www.adzuna.com",
             "fields": [
                 {

--- a/job_sources/arbeitnow.py
+++ b/job_sources/arbeitnow.py
@@ -108,6 +108,7 @@ class ArbeitnowClient(JobSource):
         """
         return {
             "display_name": "Arbeitnow",
+            "description": "European tech job board with a free, open API. Strong coverage of remote and EU-based software roles. No API key required.",
             "home_url": "https://www.arbeitnow.com",
             "fields": [],
         }

--- a/job_sources/himalayas.py
+++ b/job_sources/himalayas.py
@@ -125,6 +125,7 @@ class HimalayasClient(JobSource):
         """
         return {
             "display_name": "Himalayas",
+            "description": "Remote-first tech job board focused on software and product roles. Free API with no authentication required. High-quality listings.",
             "home_url": "https://himalayas.app",
             "fields": [],
         }

--- a/job_sources/jobicy.py
+++ b/job_sources/jobicy.py
@@ -60,6 +60,7 @@ class JobicyClient(JobSource):
         """
         return {
             "display_name": "Jobicy",
+            "description": "Remote job board with a free, unauthenticated API. Returns full job descriptions — no scraping needed. Good for remote software and data roles.",
             "fields": [],
         }
 

--- a/job_sources/jooble.py
+++ b/job_sources/jooble.py
@@ -118,6 +118,7 @@ class JoobleClient(JobSource):
         """
         return {
             "display_name": "Jooble",
+            "description": "Aggregates listings from hundreds of boards worldwide. Free API key required (register at jooble.org). Broad coverage; description quality varies.",
             "fields": [
                 {
                     "name": "api_key",

--- a/job_sources/remoteok.py
+++ b/job_sources/remoteok.py
@@ -115,6 +115,7 @@ class RemoteOKClient(JobSource):
         """
         return {
             "display_name": "Remote OK",
+            "description": "Remote-only job board with a free public API. High volume of dev, design, and tech roles worldwide. No API key required.",
             "home_url": "https://remoteok.com",
             "fields": [],
         }

--- a/job_sources/remotive.py
+++ b/job_sources/remotive.py
@@ -58,6 +58,7 @@ class RemotiveClient(JobSource):
         """
         return {
             "display_name": "Remotive",
+            "description": "Curated remote tech jobs across software, design, and marketing. Free API with no authentication. Smaller volume but strong signal-to-noise.",
             "home_url": "https://remotive.com",
             "fields": [],
         }

--- a/job_sources/the_muse.py
+++ b/job_sources/the_muse.py
@@ -137,6 +137,7 @@ class TheMuseClient(JobSource):
         """
         return {
             "display_name": "The Muse",
+            "description": "US-focused job board with company culture context. Free API with optional key to reduce rate limits. Good coverage of mid-to-large tech companies.",
             "home_url": "https://www.themuse.com",
             "fields": [],
         }

--- a/job_sources/usajobs.py
+++ b/job_sources/usajobs.py
@@ -91,6 +91,7 @@ class USAJobsClient(JobSource):
         """
         return {
             "display_name": "USAJobs",
+            "description": "Official US federal government job board. Requires a free API key and contact email from usajobs.gov. Best for government or contractor roles.",
             "home_url": "https://www.usajobs.gov",
             "fields": [
                 {

--- a/static/style.css
+++ b/static/style.css
@@ -1138,6 +1138,14 @@ body {
   color: var(--text-primary);
 }
 
+.source-description {
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: 2px 0 6px;
+  line-height: 1.5;
+}
+
 .key-status {
   font-family: var(--font-mono);
   font-size: 0.70rem;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -382,6 +382,10 @@
             {% endif %}
           </div>
 
+          {% if schema.description %}
+          <p class="source-description">{{ schema.description }}</p>
+          {% endif %}
+
           {% for field in schema.fields %}
             <label class="settings-label" for="{{ source_key }}__{{ field.name }}">
               {{ field.label }}


### PR DESCRIPTION
## Summary

- Adds a `"description"` key to `settings_schema()` for all 9 job sources (Adzuna, Arbeitnow, Himalayas, Remote OK, Remotive, The Muse, USAJobs, Jobicy, Jooble).
- Renders the description as `<p class="source-description">` in `templates/settings.html`, injected between `.provider-header` and the credential fields loop.
- Adds a `.source-description` CSS rule in `static/style.css` using `--font-body`, `--text-muted`, and `font-size: 0.82rem` — consistent with other muted helper text in the file; no hard-coded hex values.
- Documents `.source-description` in `docs/STYLE_GUIDE.md` under the Forms & Settings component table.

## Test plan

- [x] `pytest tests/test_settings_schema.py` — 66 tests pass; `_assert_schema_shape` checks only `display_name` and `fields`, so adding `description` requires no test changes.
- [x] `pytest` (full suite) — 902 tests pass.

closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)