### PR TITLE
fix: load htmx json-enc extension script in settings.html

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <link rel="stylesheet" href="/static/style.css">
   <script src="https://unpkg.com/htmx.org@1.9.10" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/json-enc.js" crossorigin="anonymous"></script>
   <style>
     /* ── Settings tab chrome ─────────────────────────────────────── */
     .settings-tabs {


### PR DESCRIPTION
## Summary

`hx-ext="json-enc"` was added to the pill toggle checkbox in #235, but the HTMX `json-enc` extension script was never loaded. HTMX silently ignores unknown extension names, so requests kept being sent as `application/x-www-form-urlencoded` and the toggle endpoint continued returning 400.

Adds the extension script tag immediately after the core HTMX script in `settings.html`:

```html
<script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/json-enc.js" crossorigin="anonymous"></script>
```

## Test plan

- [ ] Pill toggle saves enabled/disabled state without 400
- [ ] Browser DevTools Network tab shows `Content-Type: application/json` on toggle POST requests

refs #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)