### PR TITLE
fix: pre-populate model field and require all fields for configured status

### DIFF
--- a/app.py
+++ b/app.py
@@ -715,34 +715,55 @@ def ingest_status():
 def _build_llm_schemas(
     llm_section: dict,
     provider_order: list[str],
-) -> list[tuple[str, dict, bool]]:
+) -> list[tuple[str, dict, bool, dict]]:
     """Build the ordered llm_schemas list for the settings template.
 
-    Returns a list of ``(provider_key, schema_dict, has_values)`` tuples.
-    Providers in *provider_order* come first (unknown/duplicate keys skipped),
-    followed by any registry providers not listed, in registry insertion order.
+    Returns a list of ``(provider_key, schema_dict, has_values, current_values)``
+    tuples.  Providers in *provider_order* come first (unknown/duplicate keys
+    skipped), followed by any registry providers not listed, in registry
+    insertion order.
+
+    ``has_values`` is ``True`` only when every required field in the schema has
+    a non-blank stored value.  Checking all required fields (not just
+    ``api_key``) prevents a provider with a key but an empty model string from
+    falsely showing "● configured".
+
+    ``current_values`` maps non-password field names to their stored value (or
+    the field's ``default`` if not yet stored).  This dict is passed to the
+    template so that non-password inputs can be pre-populated, ensuring that
+    the placeholder default is actually submitted when the user saves without
+    explicitly editing the field.
 
     Args:
         llm_section:    The ``"llm"`` sub-dict from ``providers.json``.
         provider_order: The ``provider_order`` list from ``providers.json``.
     """
     seen: set[str] = set()
-    schemas: list[tuple[str, dict, bool]] = []
+    schemas: list[tuple[str, dict, bool, dict]] = []
+
+    def _make_entry(key: str) -> tuple[str, dict, bool, dict]:
+        cls = _PROVIDER_CLASS_MAP[key]
+        schema = cls.settings_schema()
+        cfg = llm_section.get(key) or {}
+        has_values = all(
+            bool(cfg.get(f["name"], "").strip())
+            for f in schema["fields"]
+            if f.get("required")
+        )
+        current_values = {
+            f["name"]: cfg.get(f["name"]) or f.get("default") or ""
+            for f in schema["fields"]
+            if f.get("type") != "password"
+        }
+        return (key, schema, has_values, current_values)
+
     for key in provider_order:
         if key in _PROVIDER_CLASS_MAP and key not in seen:
-            cls = _PROVIDER_CLASS_MAP[key]
-            schema = cls.settings_schema()
-            cfg = llm_section.get(key) or {}
-            has_values = bool(cfg.get("api_key", "").strip())
-            schemas.append((key, schema, has_values))
+            schemas.append(_make_entry(key))
             seen.add(key)
     for key in _PROVIDER_CLASS_MAP:
         if key not in seen:
-            cls = _PROVIDER_CLASS_MAP[key]
-            schema = cls.settings_schema()
-            cfg = llm_section.get(key) or {}
-            has_values = bool(cfg.get("api_key", "").strip())
-            schemas.append((key, schema, has_values))
+            schemas.append(_make_entry(key))
             seen.add(key)
     return schemas
 

--- a/templates/_provider_order.html
+++ b/templates/_provider_order.html
@@ -1,12 +1,12 @@
 {# _provider_order.html — drag-to-reorder list fragment.
    Context variables:
-     llm_schemas  list of (provider_key, schema_dict, has_values_bool)
+     llm_schemas  list of (provider_key, schema_dict, has_values_bool, current_values_dict)
                   in the desired display order.
    This partial is both {% include %}'d in settings.html and returned
    as an HTTP response fragment from POST /api/providers/reorder.
 #}
 <ul id="provider-order-list" class="provider-order-list">
-  {% for provider_key, schema, has_values in llm_schemas %}
+  {% for provider_key, schema, has_values, current_values in llm_schemas %}
   <li
     data-id="{{ provider_key }}"
     class="order-item{% if not has_values %} order-item--unconfigured{% endif %}">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -286,7 +286,7 @@
     <form class="settings-form" method="post" action="/settings">
       <input type="hidden" name="tab" value="llm">
 
-      {% for provider_key, schema, has_values in llm_schemas %}
+      {% for provider_key, schema, has_values, current_values in llm_schemas %}
         <div class="provider-row">
           <div class="provider-header">
             <span class="provider-name">{{ schema.display_name }}</span>
@@ -316,6 +316,7 @@
                 type="text"
                 name="{{ provider_key }}__{{ field.name }}"
                 autocomplete="off"
+                value="{{ current_values.get(field.name, field.default or '') }}"
                 placeholder="{{ field.default if field.default is defined else '' }}">
             {% endif %}
           {% endfor %}

--- a/tests/test_settings_save.py
+++ b/tests/test_settings_save.py
@@ -589,3 +589,130 @@ class TestSettingsGetEnabledCheckbox:
         # We verify by checking the remotive block does not contain checked.
         # Since other sources may also appear unchecked, just confirm the field renders.
         assert 'name="remotive__enabled"' in body
+
+
+# ===========================================================================
+# _build_llm_schemas — has_values checks all required fields (Bug #240)
+# ===========================================================================
+
+
+class TestBuildLlmSchemasHasValues:
+    """has_values must be False when any required field (not just api_key) is empty."""
+
+    def test_has_values_false_when_model_empty(
+        self, client, tmp_providers_path, tmp_keys_path, tmp_config_path
+    ):
+        """A provider with api_key set but model empty must NOT show 'configured'."""
+        import json as _json
+
+        data = {
+            "provider_order": ["anthropic"],
+            "llm": {
+                # api_key is set, but model is empty — this is the broken state
+                # that caused false "● configured" status (issue #240).
+                "anthropic": {"api_key": "sk-test", "model": ""},
+            },
+            "job_sources": {},
+        }
+        with open(tmp_providers_path, "w", encoding="utf-8") as fh:
+            _json.dump(data, fh)
+
+        from app import _build_llm_schemas
+
+        schemas = _build_llm_schemas(data["llm"], data["provider_order"])
+        # Find the anthropic entry.
+        anthropic_entry = next(
+            (e for e in schemas if e[0] == "anthropic"), None
+        )
+        assert anthropic_entry is not None, "anthropic must appear in schemas"
+        _key, _schema, has_values, _current_values = anthropic_entry
+        assert has_values is False, (
+            "has_values must be False when model is empty, even if api_key is set"
+        )
+
+    def test_has_values_true_when_all_required_fields_set(
+        self, client, tmp_providers_path, tmp_keys_path, tmp_config_path
+    ):
+        """A provider with both api_key and model set must show 'configured'."""
+        import json as _json
+
+        data = {
+            "provider_order": ["anthropic"],
+            "llm": {
+                "anthropic": {"api_key": "sk-test", "model": "claude-haiku-4-5-20251001"},
+            },
+            "job_sources": {},
+        }
+        with open(tmp_providers_path, "w", encoding="utf-8") as fh:
+            _json.dump(data, fh)
+
+        from app import _build_llm_schemas
+
+        schemas = _build_llm_schemas(data["llm"], data["provider_order"])
+        anthropic_entry = next(
+            (e for e in schemas if e[0] == "anthropic"), None
+        )
+        assert anthropic_entry is not None
+        _key, _schema, has_values, _current_values = anthropic_entry
+        assert has_values is True, (
+            "has_values must be True when all required fields (api_key and model) are set"
+        )
+
+    def test_current_values_prepopulates_model_default(
+        self, client, tmp_providers_path, tmp_keys_path, tmp_config_path
+    ):
+        """current_values must fall back to field default when model not stored."""
+        import json as _json
+
+        data = {
+            "provider_order": ["anthropic"],
+            "llm": {
+                # model not stored at all — current_values must use the schema default
+                "anthropic": {"api_key": "sk-test"},
+            },
+            "job_sources": {},
+        }
+        with open(tmp_providers_path, "w", encoding="utf-8") as fh:
+            _json.dump(data, fh)
+
+        from app import _build_llm_schemas
+
+        schemas = _build_llm_schemas(data["llm"], data["provider_order"])
+        anthropic_entry = next(
+            (e for e in schemas if e[0] == "anthropic"), None
+        )
+        assert anthropic_entry is not None
+        _key, _schema, _has_values, current_values = anthropic_entry
+        # The model default from AnthropicProvider.settings_schema() is
+        # "claude-haiku-4-5-20251001".  current_values must surface that default.
+        assert current_values.get("model") == "claude-haiku-4-5-20251001", (
+            "current_values['model'] must fall back to the schema default when not stored"
+        )
+
+    def test_current_values_does_not_include_password_fields(
+        self, client, tmp_providers_path, tmp_keys_path, tmp_config_path
+    ):
+        """Password fields must never appear in current_values (they stay blank in the form)."""
+        import json as _json
+
+        data = {
+            "provider_order": ["anthropic"],
+            "llm": {
+                "anthropic": {"api_key": "sk-secret", "model": "claude-haiku-4-5-20251001"},
+            },
+            "job_sources": {},
+        }
+        with open(tmp_providers_path, "w", encoding="utf-8") as fh:
+            _json.dump(data, fh)
+
+        from app import _build_llm_schemas
+
+        schemas = _build_llm_schemas(data["llm"], data["provider_order"])
+        anthropic_entry = next(
+            (e for e in schemas if e[0] == "anthropic"), None
+        )
+        assert anthropic_entry is not None
+        _key, _schema, _has_values, current_values = anthropic_entry
+        assert "api_key" not in current_values, (
+            "api_key (password field) must not appear in current_values"
+        )


### PR DESCRIPTION
## Summary

- Non-password fields (model ID) now pre-populated with stored value, falling back to `field.default` — so the default model is submitted on save even if the user never touches the field
- `has_values` now checks all `required: True` fields, not just `api_key` — a provider with a key but blank model correctly shows "○ not set"
- `_build_llm_schemas()` returns a 4-tuple `(key, schema, has_values, current_values)`; `_provider_order.html` updated to match
- Password fields unchanged — still blank with "leave blank to keep existing" semantics
- 4 new tests covering the exact failure modes that produced the bug

## Root cause

`save_providers()` skips blank strings to protect passwords. The model `<input>` had no `value` attribute — only a `placeholder` — so it always submitted empty, which was silently discarded. Meanwhile `has_values` only checked `api_key`, so the UI showed "● configured" while `model` was `""` in storage.

## Test plan

- [ ] `pytest` passes
- [ ] Fresh settings page: model field shows default value (not blank)
- [ ] Saving without touching the model field writes the default to `providers.json`
- [ ] Provider with key but no model shows "○ not set"
- [ ] Provider with both key and model shows "● configured"

fixes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)