### PR TITLE
chore: bump claude-actions reusable workflows from v1.4.4 to v1.5.0

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.4.4
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.5.0
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/tag-claude.yml
+++ b/.github/workflows/tag-claude.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   respond:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.4.4
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.5.0
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary
- Bumps both reusable workflow refs from `@v1.4.4` to `@v1.5.0` in the shared `cbeaulieu-gt/github-actions` library

## Files changed
- `.github/workflows/claude-pr-review.yml` — one-line version bump
- `.github/workflows/tag-claude.yml` — one-line version bump

## Test plan
- [ ] PR review workflow fires on this PR itself
- [ ] Tag/respond workflow fires on a comment after merge

closes #249

---
*Generated with [Claude Code](https://claude.ai/claude-code)*