### PR TITLE
fix: save bar blank space, duplicate button, and undo detection

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -211,7 +211,7 @@ All buttons extend `.btn` (base). Add a modifier class for semantic variants.
 | `.provider-home-link` | `<a>` | External link icon (↗) placed next to provider names on the Settings → Job Sources tab; `font-size: 0.8rem`, `var(--text-muted)` at rest, `var(--text-accent)` on hover, `transition: color 0.15s` |
 | `.source-description` | `<p>` | Short blurb below `.provider-header` on each source card; `--font-body` 0.82rem, `--text-muted`, `line-height: 1.5`; rendered only when `schema.description` is set |
 | `.save-bar` | `<div>` | Sticky unsaved-changes bar; see §5 Save Bar below |
-| `.save-bar--visible` | modifier on `.save-bar` | Added by JS when a text/password input changes; animates in via opacity + translateY |
+| `.save-bar--visible` | modifier on `.save-bar` | Added by JS when a text/password field is dirty; animates in via `max-height` + `opacity`; removed when all fields are restored to original values |
 | `.save-bar-label` | `<span>` | "Unsaved changes" text; `--font-mono` 0.8rem, `--score-mid-text` (amber — warning semantics) |
 
 ### Save Bar
@@ -231,8 +231,8 @@ Visibility is controlled by toggling `.save-bar--visible` via a delegated `input
 
 | Class | Element | Notes |
 |---|---|---|
-| `.save-bar` | `<div>` | `position: sticky; bottom: 0`; hidden at rest (`opacity: 0`, `pointer-events: none`, `translateY(4px)`) |
-| `.save-bar--visible` | modifier | Makes bar fully opaque and interactive; added/removed by JS |
+| `.save-bar` | `<div>` | `position: sticky; bottom: 0`; collapses when hidden via `max-height: 0` + `overflow: hidden` (zero padding, zero margin-top, `opacity: 0`, `pointer-events: none`) — takes up no layout space at rest |
+| `.save-bar--visible` | modifier | Expands bar (`max-height: 4rem`, full padding, `margin-top: 1rem`) and makes it opaque and interactive; added/removed by JS |
 | `.save-bar-label` | `<span>` | `--font-mono`, `--score-mid-text`; amber signals a pending-action state |
 
 ### Toggle Switch

--- a/static/style.css
+++ b/static/style.css
@@ -1267,20 +1267,23 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  margin-top: 1rem;
   background: var(--bg-surface);
   border-top: 1px solid var(--border-mid);
   border-radius: 0 0 var(--radius-md) var(--radius-md);
+  max-height: 0;
+  overflow: hidden;
+  padding: 0 1rem;
+  margin-top: 0;
   opacity: 0;
   pointer-events: none;
-  transform: translateY(4px);
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition: max-height 0.2s ease, opacity 0.2s ease, padding 0.2s ease, margin-top 0.2s ease;
 }
 .save-bar--visible {
+  max-height: 4rem;
   opacity: 1;
   pointer-events: auto;
-  transform: translateY(0);
+  padding: 0.75rem 1rem;
+  margin-top: 1rem;
 }
 .save-bar-label {
   font-size: 0.8rem;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -484,11 +484,33 @@
     var bar  = document.getElementById(cfg.barId);
     if (!form || !bar) return;
 
+    var originalSubmit = form.querySelector('button[type="submit"].btn-save');
+    if (originalSubmit) { originalSubmit.style.display = 'none'; }
+
+    // Capture original field values on page load
+    var fields = Array.from(form.querySelectorAll('input[type="text"], input[type="password"]'));
+    var originalValues = {};
+    fields.forEach(function (input) {
+      originalValues[input.name] = input.value;
+    });
+
+    function updateBarVisibility() {
+      var isDirty = fields.some(function (input) {
+        return input.value !== originalValues[input.name];
+      });
+      if (isDirty) {
+        bar.classList.add('save-bar--visible');
+        bar.removeAttribute('aria-hidden');
+      } else {
+        bar.classList.remove('save-bar--visible');
+        bar.setAttribute('aria-hidden', 'true');
+      }
+    }
+
     form.addEventListener('input', function (e) {
       var t = e.target;
       if (t.tagName === 'INPUT' && (t.type === 'text' || t.type === 'password')) {
-        bar.classList.add('save-bar--visible');
-        bar.removeAttribute('aria-hidden');
+        updateBarVisibility();
       }
     });
 


### PR DESCRIPTION
Fixes three bugs introduced in #252.

## Changes

**`static/style.css`** — `.save-bar` now collapses to zero height when hidden (`max-height: 0; overflow: hidden`) instead of just going `opacity: 0`. Eliminates the blank space gap below the provider rows.

**`templates/settings.html`** — two fixes in the dirty-state IIFE:
- Original `<button type="submit">` hidden via JS on init — no more duplicate Save buttons when the bar is visible. No-JS fallback preserved (button stays in DOM).
- `input` listener now compares against a snapshot of original field values captured on page load. Bar shows when any field differs, hides when all are restored — correctly handles the "undo your changes" case.

**`docs/STYLE_GUIDE.md`** — class table updated to reflect `max-height` collapse pattern and undo-aware visibility logic.

## Test plan
- [ ] Open Settings → both tabs show no blank space below provider rows
- [ ] Edit a field → bar slides in, original Save button is not visible
- [ ] Clear the field back to its original value → bar slides away
- [ ] Submit form → bar hides and stays hidden on reload

closes #256

---
*Generated with [Claude Code](https://claude.ai/claude-code)*