### PR TITLE
chore: update GitHub Actions for Claude to v1.6.0

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.5.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.6.0
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/lint-failure.yml
+++ b/.github/workflows/lint-failure.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run lint-failure action
         if: steps.pr.outputs.number != '' && steps.check.outputs.lint_failed == 'true'
-        uses: cbeaulieu-gt/github-actions/lint-failure@v1.5.0
+        uses: cbeaulieu-gt/github-actions/lint-failure@v1.6.0
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           gh_pat: ${{ secrets.GH_PAT }}

--- a/.github/workflows/tag-claude.yml
+++ b/.github/workflows/tag-claude.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   respond:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.5.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.6.0
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary

- Bump `claude-pr-review` reusable workflow from `v1.5.0` → `v1.6.0`
- Bump `lint-failure` action from `v1.5.0` → `v1.6.0`
- Bump `tag-claude` reusable workflow from `v1.5.0` → `v1.6.0`

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm PR Review workflow triggers correctly on a test PR after merge
- [ ] Confirm Tag Claude workflow responds correctly when tagged after merge

closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)