### PR TITLE
chore(ci): migrate lint-failure.yml to claude-lint-fix reusable workflow

### DIFF
--- a/.github/workflows/lint-failure.yml
+++ b/.github/workflows/lint-failure.yml
@@ -1,18 +1,19 @@
 name: Lint Failure
 
 on:
+  # Runs after CI completes so we can inspect its outcome and fix lint errors automatically
   workflow_run:
     workflows: ["CI"]
     types: [completed]
 
+# preflight only needs actions: read; write permissions are scoped to the lint-fix job below
 permissions:
-  contents: write
-  pull-requests: write
   actions: read
 
 jobs:
   preflight:
     runs-on: ubuntu-latest
+    # Guard here so the job exits fast when CI passed — avoids unnecessary API calls
     if: github.event.workflow_run.conclusion == 'failure'
     outputs:
       pr_number: ${{ steps.pr.outputs.number }}
@@ -40,6 +41,7 @@ jobs:
             && echo "lint_failed=true" >> $GITHUB_OUTPUT \
             || echo "lint_failed=false" >> $GITHUB_OUTPUT
 
+  # Separate job required: reusable workflows cannot be called from the same job that sets outputs
   lint-fix:
     needs: preflight
     if: needs.preflight.outputs.pr_number != '' && needs.preflight.outputs.lint_failed == 'true'
@@ -50,6 +52,7 @@ jobs:
       actions: read
     with:
       pr_number: ${{ needs.preflight.outputs.pr_number }}
+      # github.run_id would be this workflow's ID; we need the triggering CI run's ID
       run_id: ${{ github.event.workflow_run.id }}
       auto_apply: true
     secrets:


### PR DESCRIPTION
## Summary

Migrates `lint-failure.yml` from calling the `lint-failure` composite action directly to using the `claude-lint-fix.yml` reusable workflow introduced in `github-actions@v1.6.0` — the same pattern already used by `claude-pr-review.yml`.

## Changes

- **2-job split**: pre-flight steps (get PR number, check lint job failed) extracted into a `preflight` job with outputs; `lint-fix` job calls the reusable workflow via job-level `uses:` consuming those outputs
- **`actions: read` permission added**: was missing from the caller — required for `gh run view --log-failed` inside the action
- **`auto_apply: true`** (boolean, not string `'true'`): matches the reusable workflow's `boolean` input type
- **`run_id: ${{ github.event.workflow_run.id }}`**: correctly references the failed CI run (not the current handler run — the reusable workflow's input description is misleading on this point)
- **Secrets via `secrets:` block**: consistent with `claude-pr-review.yml` pattern

## Test plan

- [ ] CI passes on this PR
- [ ] Trigger a lint failure on a test PR and confirm `preflight` runs, detects the lint failure, and `lint-fix` invokes correctly
- [ ] Confirm `auto_apply` commits a fix when Claude is high-confidence

closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)