### PR TITLE
chore(ci): rename GH_PAT secret to GH_TOKEN in workflows

### DIFF
--- a/.github/workflows/apply-fix.yml
+++ b/.github/workflows/apply-fix.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GH_TOKEN }}
           ref: refs/pull/${{ inputs.pr_number }}/head
           fetch-depth: 0
 
@@ -48,4 +48,4 @@ jobs:
           BRANCH=$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }} --jq '.head.ref')
           git push origin HEAD:$BRANCH
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/lint-failure.yml
+++ b/.github/workflows/lint-failure.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get PR number
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           PR=$(gh api repos/${{ github.repository }}/pulls \
             --jq ".[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\") | .number" \
@@ -33,7 +33,7 @@ jobs:
       - name: Check if lint job failed
         id: check
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           FAILED=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs \
             --jq '[.jobs[] | select(.conclusion == "failure") | .name]')
@@ -57,4 +57,4 @@ jobs:
       auto_apply: true
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      gh_pat: ${{ secrets.GH_PAT }}
+      gh_pat: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

- Renames all references to `secrets.GH_PAT` → `secrets.GH_TOKEN` in `.github/workflows/apply-fix.yml` and `.github/workflows/lint-failure.yml` (5 occurrences total)

## Before merging

> **Action required:** The repo secret must be renamed from `GH_PAT` to `GH_TOKEN` in **GitHub Settings → Secrets and variables → Actions** before this PR is merged. Merging without renaming the secret will cause the `Apply Claude Fix` and `Lint Failure` workflows to fail with auth errors.

## Test plan

- [ ] Rename the repo secret `GH_PAT` → `GH_TOKEN` in GitHub Settings
- [ ] Merge this PR
- [ ] Trigger a lint failure on a test PR and confirm the `Lint Failure` workflow authenticates successfully
- [ ] Trigger the `Apply Claude Fix` workflow manually and confirm the checkout and push steps succeed

> Generated with [Claude Code](https://claude.ai/claude-code)