### PR TITLE
chore(ci): bump cbeaulieu-gt/github-actions from v1.6.0 to v1.6.1

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.6.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.6.1
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/lint-failure.yml
+++ b/.github/workflows/lint-failure.yml
@@ -45,7 +45,7 @@ jobs:
   lint-fix:
     needs: preflight
     if: needs.preflight.outputs.pr_number != '' && needs.preflight.outputs.lint_failed == 'true'
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-lint-fix.yml@v1.6.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-lint-fix.yml@v1.6.1
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tag-claude.yml
+++ b/.github/workflows/tag-claude.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   respond:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.6.0
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.6.1
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
Bumps all three workflow references from `v1.6.0` to `v1.6.1`:

- `.github/workflows/lint-failure.yml` — `claude-lint-fix.yml@v1.6.1`
- `.github/workflows/tag-claude.yml` — `claude-tag-respond.yml@v1.6.1`
- `.github/workflows/claude-pr-review.yml` — `claude-pr-review.yml@v1.6.1`

This picks up the fix for the `track_progress` crash in `lint-failure.yml` (cbeaulieu-gt/github-actions#64).

closes #301

> Generated with [Claude Code](https://claude.com/claude-code)