### PR TITLE
chore(ci): bump cbeaulieu-gt/github-actions from v1.6.1 to v1.6.3

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.6.1
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v1.6.3
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/lint-failure.yml
+++ b/.github/workflows/lint-failure.yml
@@ -45,7 +45,7 @@ jobs:
   lint-fix:
     needs: preflight
     if: needs.preflight.outputs.pr_number != '' && needs.preflight.outputs.lint_failed == 'true'
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-lint-fix.yml@v1.6.1
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-lint-fix.yml@v1.6.3
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tag-claude.yml
+++ b/.github/workflows/tag-claude.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   respond:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.6.1
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v1.6.3
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
Bumps `cbeaulieu-gt/github-actions` across all three workflow files from `v1.6.1` to `v1.6.3`, picking up both patch releases:

- **v1.6.2** — adds `--allowedTools` to `claude_args` in the lint-failure action; Claude Code's non-interactive SDK mode denies all tool calls by default, so without this flag the action hit permission errors immediately and produced no output ([github-actions#66](https://github.com/cbeaulieu-gt/github-actions/issues/66))
- **v1.6.3** — raises `max_turns` default from 10 → 20; the 10-turn limit was too tight for the minimum happy-path tool sequence (read files, post comment, write patch, apply, commit, push) ([github-actions#70](https://github.com/cbeaulieu-gt/github-actions/issues/70))

## Files changed

- `.github/workflows/lint-failure.yml`
- `.github/workflows/tag-claude.yml`
- `.github/workflows/claude-pr-review.yml`

closes #305

> Generated with [Claude Code](https://claude.ai/claude-code)