### PR TITLE
docs: update README setup instructions to use providers.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Copy-Item config\profile.example.json config\profile.json
 
 **5. Fill in `config/config.json`**
 
-`config/config.json` holds Adzuna-specific search settings and global scoring/filter options. Which sources are enabled and any source-specific credentials (other than Adzuna) are configured via the `/settings` UI after starting the web server.
+`config/config.json` holds Adzuna-specific search parameters (`country`, `what`, `where`, etc.) and global scoring/filter options. Which sources are enabled and all source credentials (including Adzuna) are configured via the `/settings` UI after starting the web server.
 
 LLM provider keys (Anthropic, OpenAI, Gemini) are configured via `config/providers.json` and the `/settings` UI.
 


### PR DESCRIPTION
## Summary

- Replace all `config/keys.json` / `config/keys.example.json` references in the Setup, Windows deployment, and automated deployment sections with the current `config/providers.json` / `config/providers.example.json` equivalents
- Reframe the `/settings` UI as the primary credential configuration path (validates keys before saving)
- Add a brief migration callout for existing `keys.json` installs (auto-migrated on first run — no manual action needed)
- Fix a stale post-setup note that sent users to `config/config.json` for Adzuna credentials, which now live in `providers.json`

## Test plan

- [ ] Verify `grep -n "keys.json" README.md` returns only the intentional migration note (line ~58)
- [ ] Follow the updated Step 4 copy commands end-to-end in a fresh clone to confirm they produce a working `providers.json`
- [ ] Confirm `pytest` still passes (1060 tests, doc-only change)

> Generated with [Claude Code](https://claude.ai/claude-code)