### PR TITLE
fix(style): replace all hard-coded hex values with CSS custom properties

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -79,6 +79,51 @@ Applied to `.card-details` via `data-tier` attribute.
 | `--btn-hover` | `#262e3f` |
 | `--btn-border` | `#373e50` |
 
+### Amber-accented button states
+
+Used by `.btn-view`, `.btn-ingest`, and `.ingest-status-running` — amber-tinted interactive controls.
+
+| Token | Value | Use |
+|---|---|---|
+| `--text-accent-bright` | `#f5b040` | Hover color on amber-accented buttons; slightly brighter than `--text-accent` |
+| `--btn-amber-border` | `#3a2e10` | Border at rest for amber-accented buttons |
+| `--btn-amber-hover-bg` | `#221c08` | Hover background for amber-accented buttons |
+| `--btn-amber-hover-border` | `#5a4820` | Hover border for amber-accented buttons |
+
+### Active / filled input state
+
+Applied to `.filter-select` and `.filter-input` when they have a non-default value, and to `.btn-bookmark.bookmarked`.
+
+| Token | Value | Use |
+|---|---|---|
+| `--input-active-bg` | `#1e1500` | Background tint on active/filled inputs and bookmarked button |
+| `--input-active-border` | `#5a3a00` | Border on active/filled inputs and bookmarked button |
+
+### Applied button hover
+
+Used by `.btn-apply.applied:hover` — a brighter green to signal confirmed action.
+
+| Token | Value | Use |
+|---|---|---|
+| `--btn-apply-hover-color` | `#2acc65` | Hover text color for applied state |
+| `--btn-apply-hover-bg` | `#0a2215` | Hover background for applied state |
+| `--btn-apply-hover-border` | `#1a5c36` | Hover border for applied state |
+
+### Dismiss button hover
+
+Used by `.btn-dismiss:hover` — dark red tint.
+
+| Token | Value | Use |
+|---|---|---|
+| `--btn-dismiss-hover-bg` | `#1a0808` | Hover background for dismiss button |
+| `--btn-dismiss-hover-border` | `#3a1010` | Hover border for dismiss button |
+
+### Misc
+
+| Token | Value | Use |
+|---|---|---|
+| `--color-white` | `#fff` | Pure white; used for the toggle-switch knob |
+
 ### Typography
 
 | Token | Stack |

--- a/static/style.css
+++ b/static/style.css
@@ -67,6 +67,28 @@
   --star-filled:    #f5a623;
   --dismiss-hover:  #ff6b6b;
 
+  /* Amber-accented button states (view, ingest) */
+  --text-accent-bright:    #f5b040;
+  --btn-amber-border:      #3a2e10;
+  --btn-amber-hover-bg:    #221c08;
+  --btn-amber-hover-border:#5a4820;
+
+  /* Filled / active input state (amber tint) */
+  --input-active-bg:     #1e1500;
+  --input-active-border: #5a3a00;
+
+  /* Applied button hover (brighter green) */
+  --btn-apply-hover-color:  #2acc65;
+  --btn-apply-hover-bg:     #0a2215;
+  --btn-apply-hover-border: #1a5c36;
+
+  /* Dismiss button hover (dark red) */
+  --btn-dismiss-hover-bg:     #1a0808;
+  --btn-dismiss-hover-border: #3a1010;
+
+  /* Pure white — used for toggle knob */
+  --color-white: #fff;
+
   /* Typography — unchanged */
   --font-body:  "Georgia", "Times New Roman", serif;
   --font-mono:  "Menlo", "Consolas", "Cascadia Code", "Courier New", monospace;
@@ -468,13 +490,13 @@ body {
 /* "View listing" — slightly more prominent */
 .btn-view {
   color: var(--text-accent);
-  border-color: #3a2e10;
+  border-color: var(--btn-amber-border);
 }
 
 .btn-view:hover {
-  background: #221c08;
-  border-color: #5a4820;
-  color: #f5b040;
+  background: var(--btn-amber-hover-bg);
+  border-color: var(--btn-amber-hover-border);
+  color: var(--text-accent-bright);
 }
 
 /* Bookmark button */
@@ -484,13 +506,13 @@ body {
 
 .btn-bookmark:hover {
   color: var(--star-filled);
-  border-color: #5a3a00;
+  border-color: var(--input-active-border);
 }
 
 .btn-bookmark.bookmarked {
   color: var(--star-filled);
-  border-color: #5a3a00;
-  background: #1e1500;
+  border-color: var(--input-active-border);
+  background: var(--input-active-bg);
 }
 
 .btn-bookmark.bookmarked:hover {
@@ -517,9 +539,9 @@ body {
 }
 
 .btn-apply.applied:hover {
-  color: #2acc65;
-  background: #0a2215;
-  border-color: #1a5c36;
+  color: var(--btn-apply-hover-color);
+  background: var(--btn-apply-hover-bg);
+  border-color: var(--btn-apply-hover-border);
 }
 
 /* Spacer pushes dismiss to the right */
@@ -538,8 +560,8 @@ body {
 
 .btn-dismiss:hover {
   color: var(--dismiss-hover);
-  background: #1a0808;
-  border-color: #3a1010;
+  background: var(--btn-dismiss-hover-bg);
+  border-color: var(--btn-dismiss-hover-border);
 }
 
 /* HTMX request indicator — dim the card while request is in-flight */
@@ -756,13 +778,13 @@ body {
 }
 
 .filter-select:has(option:not([value=""]):checked) {
-  border-color: #5a3a00;
-  background-color: #1e1500;
+  border-color: var(--input-active-border);
+  background-color: var(--input-active-bg);
   color: var(--text-accent);
 }
 .filter-input:not(:placeholder-shown) {
-  border-color: #5a3a00;
-  background-color: #1e1500;
+  border-color: var(--input-active-border);
+  background-color: var(--input-active-bg);
   color: var(--text-accent);
 }
 .filter-toggle:has(input[type="checkbox"]:checked) {
@@ -1335,7 +1357,7 @@ body {
 }
 .setup-banner p { margin: 0.2rem 0; line-height: 1.6; }
 .setup-banner a { color: var(--text-accent); text-decoration: underline; }
-.setup-banner a:hover { color: #f5b040; }
+.setup-banner a:hover { color: var(--text-accent-bright); }
 
 /* ------------------------------------------------------------
    Settings page — section wrapper
@@ -1366,13 +1388,13 @@ body {
 /* Primary action button — amber accent to signal a write operation */
 .btn-ingest {
   color: var(--text-accent);
-  border-color: #3a2e10;
+  border-color: var(--btn-amber-border);
 }
 
 .btn-ingest:hover {
-  background: #221c08;
-  border-color: #5a4820;
-  color: #f5b040;
+  background: var(--btn-amber-hover-bg);
+  border-color: var(--btn-amber-hover-border);
+  color: var(--text-accent-bright);
 }
 
 /* Optional controls alongside the button */
@@ -1404,7 +1426,7 @@ body {
   letter-spacing: 0.06em;
   color: var(--text-accent);
   background: var(--bg-surface);
-  border: 1px solid #3a2e10;
+  border: 1px solid var(--btn-amber-border);
   border-radius: var(--radius-md);
   padding: 10px 20px;
   margin-bottom: 16px;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -69,7 +69,7 @@
       gap: 0.75rem;
       padding: 0.5rem 0.75rem;
       margin-bottom: 0.3rem;
-      background: var(--card-bg, #1e1e2e);
+      background: var(--bg-raised);
       border: 1px solid var(--border-mid);
       border-radius: 6px;
       cursor: grab;
@@ -99,7 +99,7 @@
     .order-error {
       margin-top: 0.5rem;
       font-size: 0.85rem;
-      color: var(--danger, #f38ba8);
+      color: var(--score-low-text);
     }
     .sortable-ghost { opacity: 0.3; }
     .sortable-drag  { opacity: 0.9; box-shadow: 0 4px 12px rgba(0,0,0,0.4); }
@@ -129,8 +129,8 @@
       width: 36px;
       height: 20px;
       border-radius: 10px;
-      background: var(--border-mid, #2a2e3a);
-      border: 1px solid var(--border-strong, #525c72);
+      background: var(--border-mid);
+      border: 1px solid var(--border-strong);
       transition: background 0.2s, border-color 0.2s;
     }
 
@@ -142,19 +142,19 @@
       width: 14px;
       height: 14px;
       border-radius: 50%;
-      background: var(--text-muted, #7a8599);
+      background: var(--text-muted);
       transition: transform 0.2s, background 0.2s;
     }
 
     /* Checked state — amber track, knob slides right and brightens */
     .source-toggle input[type="checkbox"]:checked ~ .source-toggle-track {
-      background: var(--text-accent, #f9e2af);
-      border-color: var(--text-accent, #f9e2af);
+      background: var(--text-accent);
+      border-color: var(--text-accent);
     }
     .source-toggle input[type="checkbox"]:checked ~ .source-toggle-track .source-toggle-knob {
       /* Track(36px) - knob(14px) - left-pad(2px) - borders(2px) - right-space(2px) = 16px */
       transform: translateX(calc(36px - 14px - 6px));
-      background: #fff;
+      background: var(--color-white);
     }
 
     /* Focus ring for keyboard accessibility */


### PR DESCRIPTION
## Summary

- Replaces every hex literal outside `:root` in `static/style.css` (20 violations across buttons, filter inputs, and ingest trigger) and `templates/settings.html` (5 violations including wrong/non-existent fallback tokens) with `var(--token)` references
- Adds 12 new tokens to `:root` to cover values that had no existing semantic match, grouped by purpose (amber button states, active input state, applied/dismiss hover states, white)
- Documents all 12 new tokens in `docs/STYLE_GUIDE.md` per the style guide's own rule §7.1
- Fixes a subtle correctness bug: `settings.html` had `var(--text-accent, #f9e2af)` where the fallback `#f9e2af` (`catppuccin-mocha` yellow) didn't match the actual token value `#f5a623`; removing the fallback means the token always wins

## Test plan

- [x] All 1060 existing tests pass (`pytest`)
- [x] No hex literals remain outside `:root` in `style.css` (verified with grep)
- [x] No hex literals remain in `settings.html` inline styles (verified with grep; `&#NNNN;` HTML entities are not color values)
- [ ] Visual smoke-test: hover over View/Ingest buttons, bookmark a listing, dismiss a listing, fill a filter input, check toggle switch — all should render identically to before

closes #281

> Generated with [Claude Code](https://claude.ai/claude-code)