### PR TITLE
fix: correct htmx SRI hash and use explicit dist/htmx.min.js URL

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/static/style.css">
   <!-- htmx 1.9.10 — to update: bump the version in the URL, then regenerate the hash with:
        curl -fsSL https://unpkg.com/htmx.org@<VERSION>/dist/htmx.min.js | openssl dgst -sha384 -binary | openssl base64 -A -->
-  <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-YwQSRkoBOUtKKVfHQ8C2zCPslUZHuxiPHts6X/xQCuGHipTtRXd7ImqS1VTLlpiT" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.10/dist/htmx.min.js" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
 </head>
 <body>
 <div class="page-wrap">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -9,7 +9,7 @@
   <!-- htmx 1.9.10 — to update: bump the version in the URL, then regenerate the hash with:
        curl -fsSL https://unpkg.com/htmx.org@<VERSION>/dist/htmx.min.js | openssl dgst -sha384 -binary | openssl base64 -A
        curl -fsSL https://unpkg.com/htmx.org@<VERSION>/dist/ext/json-enc.js | openssl dgst -sha384 -binary | openssl base64 -A -->
-  <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-YwQSRkoBOUtKKVfHQ8C2zCPslUZHuxiPHts6X/xQCuGHipTtRXd7ImqS1VTLlpiT" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.10/dist/htmx.min.js" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/json-enc.js" integrity="sha384-nRnAvEUI7N/XvvowiMiq7oEI04gOXMCqD3Bidvedw+YNbj7zTQACPlRI3Jt3vYM4" crossorigin="anonymous"></script>
   <style>
     /* ── Settings tab chrome ─────────────────────────────────────── */

--- a/templates/snippets.html
+++ b/templates/snippets.html
@@ -6,7 +6,9 @@
   <title>Job Matcher · Snippets</title>
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <link rel="stylesheet" href="/static/style.css">
-  <script src="https://unpkg.com/htmx.org@1.9.10" crossorigin="anonymous"></script>
+  <!-- htmx 1.9.10 — to update: bump the version in the URL, then regenerate the hash with:
+       curl -fsSL https://unpkg.com/htmx.org@<VERSION>/dist/htmx.min.js | openssl dgst -sha384 -binary | openssl base64 -A -->
+  <script src="https://unpkg.com/htmx.org@1.9.10/dist/htmx.min.js" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
 </head>
 <body>
 <div class="page-wrap">


### PR DESCRIPTION
## Summary

Fixes a live bug where all HTMX-powered interactions were silently broken — the ingest trigger button, dismiss, bookmark, apply actions, and settings form saves all stopped working.

## Root Cause

The `<script>` URL `https://unpkg.com/htmx.org@1.9.10` (no file path) resolves via the npm package `main` field to `dist/htmx.js` (unminified). The `integrity` hash was computed against `dist/htmx.min.js` — a different file with a different hash. The browser's SRI check failed, htmx refused to execute, and HTMX was silently absent from all pages.

## Changes

| File | Fix |
|---|---|
| `templates/index.html` | Explicit URL (`/dist/htmx.min.js`), corrected hash |
| `templates/settings.html` | Same — htmx URL/hash fixed; json-enc.js hash was already correct |
| `templates/snippets.html` | Explicit URL, correct hash added; was missing `integrity` entirely |

**Old hash (wrong):** `sha384-YwQSRkoBOUtKKVfHQ8C2zCPslUZHuxiPHts6X/xQCuGHipTtRXd7ImqS1VTLlpiT`  
**New hash (verified):** `sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC`

Hash verified via:
```bash
curl -fsSL https://unpkg.com/htmx.org@1.9.10/dist/htmx.min.js | openssl dgst -sha384 -binary | openssl base64 -A
```

fixes #312

🤖 Generated with [Claude Code](https://claude.ai/claude-code)