### PR TITLE
feat(snippets): apply scoring threshold to /snippets feed

### DIFF
--- a/app.py
+++ b/app.py
@@ -508,12 +508,14 @@ def snippets():
     Accepts an optional ``sort`` query param (``'date_posted'`` or omit for score DESC).
     """
     sort = request.args.get("sort", "").strip() or None
-    listings = db.get_snippet_feed(sort=sort, db_path=DB_PATH)
+    threshold = CONFIG["scoring"]["threshold"]
+    listings = db.get_snippet_feed(threshold=threshold, sort=sort, db_path=DB_PATH)
     return render_template(
         "snippets.html",
         listings=listings,
         view="snippets",
         sort=sort,
+        threshold=threshold,
         config_warnings=_config_warnings(),
     )
 

--- a/db.py
+++ b/db.py
@@ -785,6 +785,7 @@ def get_feed(
 
 
 def get_snippet_feed(
+    threshold: float = 7.0,
     sort: str | None = None,
     db_path: str = _DEFAULT_DB_PATH,
 ) -> list[dict]:
@@ -796,12 +797,14 @@ def get_snippet_feed(
     their own dedicated view so the user can review them separately.
 
     Listings whose score is NULL are excluded (not yet scored).  Dismissed
-    listings are excluded.
+    listings are excluded.  Only listings with ``score >= threshold`` are
+    returned, mirroring the behaviour of :func:`get_feed`.
 
     Args:
-        sort:    Optional sort key.  ``'date_posted'`` orders by posted_at DESC;
-                 any other value (or None) falls back to score DESC.
-        db_path: Path to the SQLite database file.
+        threshold: Score floor (inclusive).  Defaults to 7.0.
+        sort:      Optional sort key.  ``'date_posted'`` orders by posted_at DESC;
+                   any other value (or None) falls back to score DESC.
+        db_path:   Path to the SQLite database file.
     """
     order_clause = _ALLOWED_SORT_COLUMNS.get(sort, _DEFAULT_SORT_CLAUSE)
 
@@ -809,8 +812,9 @@ def get_snippet_feed(
     try:
         rows = conn.execute(
             f"SELECT * FROM listings "
-            f"WHERE description_source = 'snippet' AND dismissed = 0 AND score IS NOT NULL "
+            f"WHERE description_source = 'snippet' AND dismissed = 0 AND score >= ? "
             f"ORDER BY {order_clause}",
+            (threshold,),
         ).fetchall()
         return [_deserialise_row(r) for r in rows]
     finally:

--- a/templates/snippets.html
+++ b/templates/snippets.html
@@ -36,6 +36,7 @@
   <div class="feed-meta">
     <strong>{{ listings | length }}</strong>
     {%- if listings | length == 1 %} snippet-scored role{% else %} snippet-scored roles{% endif %}
+    &nbsp;·&nbsp; score {{ threshold | round(1) }}+
     &nbsp;·&nbsp; sorted by {% if sort == 'date_posted' %}date posted{% else %}score{% endif %}
   </div>
 

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -316,15 +316,37 @@ class TestGetSnippetFeed:
             assert "sf-null" not in ids
 
     def test_includes_non_dismissed_snippet(self):
-        """get_snippet_feed() includes non-dismissed, scored snippet listings."""
+        """get_snippet_feed() includes non-dismissed, scored snippet listings at or above threshold."""
         with TempDB() as path:
             db.insert_listing(
                 make_listing(source_id="sf-ok", description_source="snippet", score=7.0, dismissed=0),
                 db_path=path,
             )
-            results = db.get_snippet_feed(db_path=path)
+            results = db.get_snippet_feed(threshold=7.0, db_path=path)
             ids = [r["source_id"] for r in results]
             assert "sf-ok" in ids
+
+    def test_excludes_below_threshold(self):
+        """get_snippet_feed() excludes listings whose score is below the threshold."""
+        with TempDB() as path:
+            db.insert_listing(
+                make_listing(source_id="sf-low", description_source="snippet", score=5.0, dismissed=0),
+                db_path=path,
+            )
+            results = db.get_snippet_feed(threshold=7.0, db_path=path)
+            ids = [r["source_id"] for r in results]
+            assert "sf-low" not in ids
+
+    def test_includes_at_threshold_boundary(self):
+        """get_snippet_feed() includes listings whose score equals the threshold exactly."""
+        with TempDB() as path:
+            db.insert_listing(
+                make_listing(source_id="sf-boundary", description_source="snippet", score=7.0, dismissed=0),
+                db_path=path,
+            )
+            results = db.get_snippet_feed(threshold=7.0, db_path=path)
+            ids = [r["source_id"] for r in results]
+            assert "sf-boundary" in ids
 
     def test_sort_by_date_posted(self):
         """get_snippet_feed(sort='date_posted') returns results in posted_at DESC order."""
@@ -336,12 +358,12 @@ class TestGetSnippetFeed:
                 db_path=path,
             )
             db.insert_listing(
-                make_listing(source_id="sf-new", description_source="snippet", score=6.0,
+                make_listing(source_id="sf-new", description_source="snippet", score=7.0,
                              posted_at="2026-02-01T00:00:00Z",
                              redirect_url="https://example.com/b"),
                 db_path=path,
             )
-            results = db.get_snippet_feed(sort="date_posted", db_path=path)
+            results = db.get_snippet_feed(threshold=5.0, sort="date_posted", db_path=path)
             ids = [r["source_id"] for r in results]
             assert ids.index("sf-new") < ids.index("sf-old")
 
@@ -349,7 +371,7 @@ class TestGetSnippetFeed:
         """get_snippet_feed() defaults to score DESC when sort is not specified."""
         with TempDB() as path:
             db.insert_listing(
-                make_listing(source_id="sf-lo", description_source="snippet", score=5.0,
+                make_listing(source_id="sf-lo", description_source="snippet", score=7.5,
                              redirect_url="https://example.com/c"),
                 db_path=path,
             )
@@ -358,7 +380,7 @@ class TestGetSnippetFeed:
                              redirect_url="https://example.com/d"),
                 db_path=path,
             )
-            results = db.get_snippet_feed(db_path=path)
+            results = db.get_snippet_feed(threshold=7.0, db_path=path)
             ids = [r["source_id"] for r in results]
             assert ids.index("sf-hi") < ids.index("sf-lo")
 
@@ -512,9 +534,9 @@ class TestSnippetsRoute:
         assert b"No snippet-scored listings" in response.data
 
     def test_snippets_route_shows_snippet_badge(self):
-        """GET /snippets renders the snippet badge on each card."""
+        """GET /snippets renders the snippet badge on each card (listing at threshold)."""
         db.insert_listing(
-            make_listing(source_id="route-001", description_source="snippet", score=7.0),
+            make_listing(source_id="route-001", description_source="snippet", score=8.0),
             db_path=self.db_path,
         )
         response = self.client.get("/snippets")
@@ -529,6 +551,39 @@ class TestSnippetsRoute:
         )
         response = self.client.get("/snippets")
         assert b"route-full" not in response.data
+
+    def test_snippets_route_hides_below_threshold(self):
+        """GET /snippets does not render snippet listings whose score is below the threshold."""
+        import app as flask_app
+        # Insert one listing below CONFIG threshold and one above it.
+        # Use distinct redirect URLs so we can locate each card in the HTML.
+        threshold = flask_app.CONFIG["scoring"]["threshold"]
+        db.insert_listing(
+            make_listing(source_id="route-below", description_source="snippet",
+                         score=threshold - 1.0,
+                         redirect_url="https://example.com/job-below-threshold"),
+            db_path=self.db_path,
+        )
+        db.insert_listing(
+            make_listing(source_id="route-above", description_source="snippet",
+                         score=threshold + 1.0,
+                         redirect_url="https://example.com/job-above-threshold"),
+            db_path=self.db_path,
+        )
+        response = self.client.get("/snippets")
+        # The redirect_url is rendered in each card's "view listing" anchor href.
+        assert b"job-below-threshold" not in response.data
+        assert b"job-above-threshold" in response.data
+
+    def test_snippets_route_shows_threshold_in_subtitle(self):
+        """GET /snippets renders the score threshold in the subtitle line."""
+        import app as flask_app
+        threshold = flask_app.CONFIG["scoring"]["threshold"]
+        response = self.client.get("/snippets")
+        body = response.data.decode("utf-8")
+        # The subtitle renders e.g. "score 7.0+"
+        expected = f"score {threshold:.1f}+"
+        assert expected in body
 
     def test_snippets_nav_tab_is_active(self):
         """GET /snippets marks the feed top-level tab and snippets sub-tab as active."""


### PR DESCRIPTION
## Summary

- `db.get_snippet_feed()` now accepts a `threshold` parameter and applies `score >= ?` to its WHERE clause — excluding low-scoring listings the same way the main feed does
- `/snippets` route reads `CONFIG["scoring"]["threshold"]` and passes it through to the DB query and template
- Snippets subtitle now shows the active threshold (e.g. *"14 snippet-scored roles · score 7.0+ · sorted by score"*)

## Test plan

- [x] 33 snippet tests pass (including 2 new threshold-specific tests and 2 new route-level tests)
- [x] Full suite: 1138 pass, 5 pre-existing geo_filter failures (present on `main` before this branch)
- [x] Subtitle renders threshold correctly
- [x] Listings below threshold are excluded from the snippet feed

closes #316

🤖 Generated with [Claude Code](https://claude.ai/claude-code)