### PR TITLE
docs: replace hardcoded localhost URLs with page name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The database file `jobs.db` is created automatically on the first run.
 python app.py
 ```
 
-Then open `http://localhost:5000` in your browser.
+Then open the web UI in your browser.
 
 > **Security note:** Job Matcher is a localhost-only tool. All state-mutating
 > requests (POST/PUT/PATCH/DELETE) are rejected with 403 if the `Origin` or
@@ -265,7 +265,7 @@ What it does:
 - Registers the `JobMatcherIngest` daily Task Scheduler task
 - Opens Windows Firewall inbound TCP port 5000 so the UI is reachable from the network
 
-After the script completes, navigate to `http://localhost:5000/settings` to configure your LLM provider API keys and any job source credentials (including Adzuna App ID and App Key).
+After the script completes, open the **Settings** page to configure your LLM provider API keys and any job source credentials (including Adzuna App ID and App Key).
 
 ### Prerequisites
 
@@ -349,7 +349,7 @@ The SQLite database (`jobs.db`) is created there automatically on the first run.
 
 ### API keys (LLM providers)
 
-LLM provider keys (Anthropic, OpenAI, Gemini, etc.) are stored in `config/providers.json` alongside job source credentials. The file is gitignored and never committed. After running `scripts/setup.ps1`, navigate to `http://localhost:5000/settings` to enter your API keys — the Settings UI validates each key before saving.
+LLM provider keys (Anthropic, OpenAI, Gemini, etc.) are stored in `config/providers.json` alongside job source credentials. The file is gitignored and never committed. After running `scripts/setup.ps1`, open the **Settings** page to enter your API keys — the Settings UI validates each key before saving.
 
 ### Ops commands
 

--- a/docs/superpowers/plans/2026-03-30-drag-to-reorder-provider-priority.md
+++ b/docs/superpowers/plans/2026-03-30-drag-to-reorder-provider-priority.md
@@ -563,7 +563,7 @@ Expected: all tests pass, 0 failures.
 
 - [ ] **Step 5: Manual smoke test**
 
-Start the app (`python app.py`) and navigate to `http://localhost:5000/settings`.
+Start the app (`python app.py`) and open the **Settings** page.
 
 Verify:
 - [ ] The LLM Providers tab shows a "Fallback Order" section above the provider cards

--- a/docs/superpowers/plans/2026-03-30-scoring-instructions.md
+++ b/docs/superpowers/plans/2026-03-30-scoring-instructions.md
@@ -930,7 +930,7 @@ Expected: all pre-existing tests pass + all new tests green.
 ### Manual end-to-end checklist
 Start the server: `python app.py`
 
-- [ ] `http://localhost:5000/profile` loads without errors.
+- [ ] The **Profile** page loads without errors.
 - [ ] "Scoring Instructions" section visible below config.json editor.
 - [ ] Textarea shows current `scoring_notes` from `profile.json`, one per line.
 - [ ] Listing dropdown shows title, company, and score (`7/10`).


### PR DESCRIPTION
## Summary

Follow-on to the pre-1.0 docs audit (#329 / #330). The initial audit PR missed hardcoded `http://localhost:PORT/...` navigable URLs in several docs files. This PR replaces all such instances with plain page-name references so docs remain valid regardless of port or host.

**Changed:**
- `README.md` — 3 instances: "open `http://localhost:5000`" → "open the web UI"; two "navigate to `http://localhost:5000/settings`" → "open the **Settings** page"
- `docs/superpowers/plans/2026-03-30-drag-to-reorder-provider-priority.md` — smoke test step: `http://localhost:5000/settings` → "the **Settings** page"
- `docs/superpowers/plans/2026-03-30-scoring-instructions.md` — checklist item: `http://localhost:5000/profile` → "the **Profile** page"

**Wiki (committed directly to wiki master):**
- `Getting-Started.md` — `http://localhost:5000/settings` → "the **Settings** page"; `http://localhost:5000` → "the web UI"
- `Troubleshooting.md` — "default is `http://localhost:5000`" → "app serves on port 5000 by default"

**Kept (legitimate uses):**
- Startup command comments in `CLAUDE.md` and `CONTRIBUTING.md` (`# http://localhost:5000`) — these communicate the default bind address
- Security note / CSRF explanation text — `localhost` is a technical term there, not a navigable URL

refs #329

## Test plan
- [ ] Grep `http://localhost` across all `.md` files — only the two startup command comments should remain
- [ ] Read changed sections to confirm the replacement text is natural and unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)