### PR TITLE
fix: update og:url and footer profile link to christopherbeaulieu.net

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
   <meta property="og:description" content="Job Matcher is an open-source pipeline that fetches listings from nine job boards, scores each one against your skills using an LLM, and surfaces ranked results in a local web UI. Your data never leaves your machine.">
   <meta property="og:image" content="assets/feed-overview.png">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://cbeaulieu-gt.github.io/job-matcher/">
+  <meta property="og:url" content="https://christopherbeaulieu.net/job-matcher/">
 
   <meta name="theme-color" content="#0f1117">
 
@@ -1221,9 +1221,9 @@
         <span>Built by</span>
         <span class="footer-author-name">Christopher Beaulieu</span>
         <a
-          href="https://github.com/cbeaulieu-gt"
+          href="https://christopherbeaulieu.net"
           class="footer-icon-link"
-          aria-label="Christopher Beaulieu on GitHub"
+          aria-label="Christopher Beaulieu — personal site"
           rel="noopener noreferrer"
           target="_blank"
         >


### PR DESCRIPTION
Two-line update now that the site resolves at the custom domain.

- `og:url` → `https://christopherbeaulieu.net/job-matcher/`
- Footer author profile link → `https://christopherbeaulieu.net`

🤖 Generated with [Claude Code](https://claude.com/claude-code)