### PR TITLE
feat: acknowledge community contribution in landing page footer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1215,6 +1215,8 @@
         </a>
         <span class="footer-sep" aria-hidden="true">·</span>
         <span>MIT License</span>
+        <span class="footer-sep" aria-hidden="true">·</span>
+        <span>One community contribution accepted</span>
       </div>
 
       <div class="footer-author">


### PR DESCRIPTION
Adds "One community contribution accepted" to the footer alongside the MIT license line.

Honest attribution — a DB query optimization was submitted from an external fork and merged. Subtle enough not to imply a team project, present enough to be accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)