### PR TITLE
fix: screenshot placeholders hide correctly when images load

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -589,6 +589,8 @@
       width: 100%;
       max-width: 100%;
       display: block;
+      position: relative;
+      z-index: 1;
     }
 
     /* Placeholder shown when image hasn't loaded */


### PR DESCRIPTION
## Summary

- Adds `position: relative; z-index: 1` to `.screenshot-container img` so images stack above their absolutely-positioned placeholder divs once loaded
- Mirrors the identical fix already present on `.hero-screenshot img`

## Root cause

`.screenshot-placeholder` is `position: absolute`, which places it above non-positioned elements in CSS stacking order. `.screenshot-container img` had no `position` set, so the placeholder text rendered on top of the image even after a successful load — making filenames like `feed-overview.png` permanently visible in the center of each screenshot slot.

## Test plan

- [ ] Open `docs/index.html` in a browser with the screenshot assets present — placeholder text should not be visible
- [ ] Remove/rename an asset — placeholder text should appear as a fallback

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)