### PR TITLE
fix(workflows): pass App secrets to claude-pr-review caller (verify secrets first)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,5 +12,4 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
-    secrets:
-      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Fixes the caller-workflow contract for `claude-pr-review.yml` so that the reusable workflow receives the App secrets it now requires.

- Replaces the explicit `secrets:` block (which only forwarded `CLAUDE_CODE_OAUTH_TOKEN`) with `secrets: inherit`, passing all repo secrets including `APP_ID` and `APP_PRIVATE_KEY`
- Keeps the existing `permissions:` block unchanged

## ⚠️ Secret-availability caveat — verify before merging

API enumeration of this repo's Actions secrets returned **only** `CLAUDE_CODE_OAUTH_TOKEN` and `GH_TOKEN`. `APP_ID` and `APP_PRIVATE_KEY` may exist via the GitHub UI (environment-scoped, or visible to the account but not the API session) — or they may be genuinely absent.

**Before merging, verify via:**
> Settings → Secrets and variables → Actions → Repository secrets

If `APP_ID` and `APP_PRIVATE_KEY` are **not** listed there, `secrets: inherit` will forward them as empty strings and the workflow will still fail with "No authentication token provided". In that case, add the secrets first, then merge this PR.

See [issue #353](https://github.com/cbeaulieu-gt/job-matcher/issues/353) for the full verification context.

## Before / after

```yaml
# Before
    secrets:
      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

# After
    secrets: inherit
```

## Why this is needed

`glitchwerks/github-actions` PR [#252](https://github.com/glitchwerks/github-actions/pull/252) switched all Claude-powered workflows to a GitHub App token identity. The reusable workflow now requires `app_id` and `app_private_key` inputs (passed via secrets) to generate a short-lived token. The previous explicit `secrets:` block only forwarded `CLAUDE_CODE_OAUTH_TOKEN`, so the App token generation step received no credentials and failed.

Related upstream issue tracking secret-availability documentation: glitchwerks/github-actions#260.

## CI signal

This PR uses `pull_request` as its trigger, so the PR's own `claude-pr-review` check will exercise the fixed workflow. If `APP_ID`/`APP_PRIVATE_KEY` are genuinely absent, that check will fail — which is the real signal that secrets need to be added before merging.

Closes #353

---

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_