### PR TITLE
docs: codify cross-repo xref convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,10 @@ pytest -k "test_title_include"     # By name pattern
 # (emits a warning). This prevents accidental data loss on dev/prod databases.
 ```
 
+## Cross-repo references
+
+This repo (`glitchwerks/job-matcher`) is the public successor to a predecessor private repo (`glitchwerks/job-matcher-pr`), which is retained for issue history. Use the fully-qualified form `glitchwerks/job-matcher-pr#N` whenever referencing an issue or PR from that predecessor repo — in commit messages, issue bodies, PR bodies, and committed docs. Reserve bare `#N` for issues and PRs in this repo only. GitHub auto-links bare `#N` to the current repo, so a bare reference to a predecessor issue silently points at the wrong place.
+
 ## Architecture
 
 The app is two decoupled processes sharing a PostgreSQL database (connection via `DATABASE_URL`):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,10 @@ scripts/           Linux/Docker deployment helpers (docker-setup.sh, docker-stat
 - Commit messages: imperative mood, present tense (`fix:`, `feat:`, `chore:`, `docs:`, `test:`)
 - Reference the issue number in the commit message: `fixes #N` or `closes #N`
 
+### Cross-repo references
+
+This repo (`glitchwerks/job-matcher`) is the public successor to a predecessor private repo (`glitchwerks/job-matcher-pr`), which is retained for issue history. When referencing an issue or PR from that predecessor repo — in commit messages, issue bodies, PR bodies, or docs — always use the fully-qualified form `glitchwerks/job-matcher-pr#N`. Use bare `#N` only for issues and PRs in this repo. GitHub auto-links bare `#N` to the current repo, so an unqualified predecessor reference silently points at the wrong place.
+
 ---
 
 ## Branching and PRs


### PR DESCRIPTION
## Summary

Documents the cross-repo reference convention established during the #734 xref-rot cleanup:

- `glitchwerks/job-matcher-pr#N` — references to issues/PRs in the predecessor private repo
- `#N` — references to issues/PRs in this repo only

Added as a new section in `CLAUDE.md` and a new `### Cross-repo references` subsection under `## Conventions` in `CONTRIBUTING.md`. Additive only — no existing content restructured.

Closes #736.

## Test plan

- [x] `CLAUDE.md` renders the new section in GitHub preview
- [x] `CONTRIBUTING.md` renders the new subsection under `## Conventions`
- [ ] CI passes (docs-only change; should be a no-op for any code checks)

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*