### PR TITLE
feat(#644): wire Docker file-based secrets for DB password

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -41,7 +41,9 @@ jobs:
           cache-to: type=gha,mode=max
 
       # The compose env files only need POSTGRES_* credentials and SECRET_KEY.
-      # DATABASE_URL, FLASK_DEBUG, etc. are set in the compose environment: block.
+      # POSTGRES_USER and POSTGRES_DB are passed to the web container via the
+      # environment: block so entrypoint.sh can construct DATABASE_URL from
+      # POSTGRES_USER + /run/secrets/db_password + POSTGRES_DB.
       # Use printf to avoid heredoc indentation issues inside YAML run blocks.
       # SECRET_KEY is generated fresh per run — the value only needs to be non-empty
       # and random; it is not persisted beyond this workflow execution.
@@ -52,6 +54,15 @@ jobs:
             "${{ env.POSTGRES_USER }}" "${{ env.POSTGRES_PASSWORD }}" "$SECRET_KEY" > .env.dev
           printf 'POSTGRES_USER=%s\nPOSTGRES_PASSWORD=%s\nPOSTGRES_DB=jobmatcher_prod\nSECRET_KEY=%s\n' \
             "${{ env.POSTGRES_USER }}" "${{ env.POSTGRES_PASSWORD }}" "$SECRET_KEY" > .env.prod
+
+      # Create the DB password secret files required by the compose secrets: stanza.
+      # entrypoint.sh reads /run/secrets/db_password and constructs DATABASE_URL;
+      # without these files `docker compose up` will fail to start the web service.
+      - name: Create test secret files
+        run: |
+          mkdir -p secrets
+          printf '%s\n' "${{ env.POSTGRES_PASSWORD }}" > secrets/db_password.dev
+          printf '%s\n' "${{ env.POSTGRES_PASSWORD }}" > secrets/db_password.prod
 
       # Create config directories and populate them from example files so the
       # Flask app has valid (if empty) config on first boot.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ config/providers.json
 config/providers.json.lock
 config-dev/
 
+# Docker file-based secrets — ignore live password files, track scaffolding only.
+# Note: negation (!pattern) cannot un-ignore files inside an ignored directory,
+# so we ignore individual secret files rather than the whole directory.
+secrets/db_password.dev
+secrets/db_password.prod
+
 # Database
 jobs.db
 jobs.demo.db

--- a/README.md
+++ b/README.md
@@ -443,9 +443,15 @@ For full documentation — stack architecture, environment variables, CI/CD pipe
 sudo git clone https://github.com/glitchwerks/job-matcher.git /opt/job-matcher-pr
 cd /opt/job-matcher-pr
 
+# Create DB password secret files from the example (one per environment)
+cp secrets/db_password.example secrets/db_password.dev   # then edit with your dev password
+cp secrets/db_password.example secrets/db_password.prod  # then edit with your prod password
+
 # One-time VM provisioning: creates directories, copies config examples, starts both stacks
 sudo ./scripts/docker-setup.sh
 ```
+
+> **DB password secret files:** The database password now lives in `secrets/db_password.{dev,prod}` rather than in `DATABASE_URL` inside `.env.*`. `scripts/entrypoint.sh` reads `/run/secrets/db_password` at container start and constructs `DATABASE_URL` from `POSTGRES_USER` + the secret file + `POSTGRES_DB`. The `.env.*` files no longer need `DATABASE_URL` and `POSTGRES_PASSWORD` is only required by the `db` service for initial database creation. The `secrets/` files are gitignored — only `secrets/db_password.example` (a placeholder) and `secrets/.gitkeep` are tracked.
 
 ### Pushing updates to a remote server
 
@@ -455,7 +461,7 @@ sudo ./scripts/docker-setup.sh
 ./scripts/deploy-remote-linux.sh <host>
 ```
 
-The script pushes compose files, helper scripts, and config examples over SSH, then prompts before overwriting the live `.env.prod` / `.env.dev` files and chmod 600s them after copying. It handles sudo and TTY requirements automatically.
+The script pushes compose files, helper scripts, config examples, and live secret files over SSH, then prompts before overwriting the live `.env.prod` / `.env.dev` and `secrets/db_password.*` files, and chmod 600s them after copying. It handles sudo and TTY requirements automatically.
 
 If you prefer to update the server directly, SSH in and diff `.env.prod` against `.env.prod.example` (`diff .env.prod .env.prod.example`), add any new keys by hand, then recreate the stack (`docker compose ... down && ... up -d`) to pick up the changes — compose freezes env vars at container creation time.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,8 +48,13 @@ services:
     volumes:
       - ./config-dev:/app/config:rw   # rw required: /settings UI writes providers.json
       - ./logs-dev:/app/logs:rw
+    secrets:
+      - db_password
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/jobmatcher_dev
+      # DATABASE_URL is constructed by entrypoint.sh from POSTGRES_USER +
+      # /run/secrets/db_password + POSTGRES_DB. Do not set DATABASE_URL here.
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_DB: jobmatcher_dev
       SECRET_KEY: '${SECRET_KEY:?SECRET_KEY must be set in .env.dev — generate with: python -c ''import secrets; print(secrets.token_hex(32))''}'
       FLASK_DEBUG: "0"
       LOG_DIR: "/app/logs"
@@ -78,3 +83,7 @@ services:
 
 volumes:
   pgdata_dev:
+
+secrets:
+  db_password:
+    file: ./secrets/db_password.dev

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,8 +36,13 @@ services:
     volumes:
       - ./config:/app/config:rw   # rw required: /settings UI writes providers.json
       - ./logs:/app/logs:rw
+    secrets:
+      - db_password
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/jobmatcher_prod
+      # DATABASE_URL is constructed by entrypoint.sh from POSTGRES_USER +
+      # /run/secrets/db_password + POSTGRES_DB. Do not set DATABASE_URL here.
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_DB: jobmatcher_prod
       SECRET_KEY: '${SECRET_KEY:?SECRET_KEY must be set in .env.prod — generate with: python -c ''import secrets; print(secrets.token_hex(32))''}'
       FLASK_DEBUG: "0"
       LOG_DIR: "/app/logs"
@@ -66,3 +71,7 @@ services:
 
 volumes:
   pgdata_prod:
+
+secrets:
+  db_password:
+    file: ./secrets/db_password.prod

--- a/scripts/deploy-remote-linux.sh
+++ b/scripts/deploy-remote-linux.sh
@@ -365,6 +365,82 @@ for LIVE_ENV in .env.prod .env.dev; do
     fi
 done
 
+# --- Live secrets/db_password.* files (opt-in, with overwrite confirmation + chmod 600) ---
+#
+# The DB password now lives in secrets/db_password.{dev,prod} rather than in
+# DATABASE_URL inside the .env file. entrypoint.sh reads /run/secrets/db_password
+# and constructs DATABASE_URL at container start. These files must be present on
+# the remote before `docker compose up` or the web container falls back to the
+# (absent) DATABASE_URL env var and will fail to connect.
+#
+# Mirrors the live .env push pattern above: stage to /tmp, sudo-install to the
+# final path with 600 permissions, then clean up the temp file.
+# shellcheck disable=SC2029  # ${REMOTE_PATH} and ${SSH_TARGET} intentionally expand client-side
+ssh "${SSH_TARGET}" "mkdir -p '${REMOTE_PATH}/secrets'"
+ok "Remote secrets/ directory ensured."
+
+for SECRET_FILE in secrets/db_password.prod secrets/db_password.dev; do
+    LOCAL_SECRET="${LOCAL_PROJECT_ROOT}/${SECRET_FILE}"
+    REMOTE_SECRET="${REMOTE_PATH}/${SECRET_FILE}"
+    SECRET_BASENAME="$(basename "${SECRET_FILE}")"
+
+    if [[ ! -f "${LOCAL_SECRET}" ]]; then
+        # No local secret file -> nothing to push. Operator must create it manually.
+        warn "Local ${SECRET_FILE} not found -- skipping. Create it from secrets/db_password.example before deploying."
+        continue
+    fi
+
+    # Pre-push sanity check: catch placeholder values before they go to the wire.
+    if grep -qE '^changeme' "${LOCAL_SECRET}"; then
+        echo ""
+        warn "Local ${SECRET_FILE} still contains a 'changeme' placeholder password."
+        if [[ "${SECRET_FILE}" == *prod* ]]; then
+            read -r -p "Push anyway? The prod stack will use this weak password. [y/N] " PUSH_ANYWAY
+        else
+            read -r -p "Push anyway? Not recommended for deployed environments. [y/N] " PUSH_ANYWAY
+        fi
+        echo ""
+        if [[ ! "${PUSH_ANYWAY}" =~ ^[Yy]$ ]]; then
+            warn "Skipped ${SECRET_FILE} -- remote unchanged."
+            continue
+        fi
+    fi
+
+    # Check whether the remote already has the secret and confirm overwrite.
+    # shellcheck disable=SC2029  # ${REMOTE_SECRET} and ${SSH_TARGET} intentionally expand client-side
+    if ssh "${SSH_TARGET}" "[[ -f '${REMOTE_SECRET}' ]]" 2>/dev/null; then
+        echo ""
+        warn "Remote already has a live ${SECRET_FILE} at ${REMOTE_PATH}."
+        warn "Overwriting will replace the DB password the running stack is using."
+        read -r -p "Overwrite remote ${SECRET_FILE} with the local copy? [y/N] " CONFIRM_OVERWRITE
+        echo ""
+        if [[ ! "${CONFIRM_OVERWRITE}" =~ ^[Yy]$ ]]; then
+            warn "Skipped live ${SECRET_FILE} -- remote unchanged."
+            continue
+        fi
+    fi
+
+    # Stage-then-install: same atomic pattern as the .env push above.
+    # shellcheck disable=SC2029  # ${SECRET_BASENAME} and ${SSH_TARGET} intentionally expand client-side
+    REMOTE_TMP=$(ssh "${SSH_TARGET}" "mktemp /tmp/.${SECRET_BASENAME}.XXXXXX")
+    if [[ -z "${REMOTE_TMP}" ]]; then
+        warn "Could not create temp file on remote -- skipped ${SECRET_FILE}."
+        continue
+    fi
+    scp -q "${LOCAL_SECRET}" "${SSH_TARGET}:${REMOTE_TMP}"
+    # shellcheck disable=SC2029  # ${REMOTE_TMP} and ${SSH_TARGET} intentionally expand client-side
+    ssh "${SSH_TARGET}" "chmod 600 '${REMOTE_TMP}'"
+    # shellcheck disable=SC2029  # ${REMOTE_TMP}, ${REMOTE_SECRET}, ${SSH_TARGET} intentionally expand client-side
+    if ssh -tt "${SSH_TARGET}" "sudo install -m 600 -o \"\$(id -un)\" -g \"\$(id -gn)\" '${REMOTE_TMP}' '${REMOTE_SECRET}'"; then
+        ssh "${SSH_TARGET}" "rm -f '${REMOTE_TMP}'" 2>/dev/null || true
+        ok "Copied live ${SECRET_FILE} (chmod 600)"
+    else
+        warn "sudo install failed for ${SECRET_FILE} (see output above for details)."
+        ssh "${SSH_TARGET}" "rm -f '${REMOTE_TMP}'" 2>/dev/null || true
+        continue
+    fi
+done
+
 # --- Fix line endings (Windows → Unix) ---
 # scp from a Windows workstation copies files with CRLF line endings.
 # Bash on the remote will choke on \r in shell scripts (e.g. "set -euo pipefail\r"

--- a/secrets/db_password.example
+++ b/secrets/db_password.example
@@ -1,0 +1,1 @@
+changeme_db_password


### PR DESCRIPTION
## Summary

Wire Docker file-based secrets into both compose files for the DB password, keeping the plaintext password out of container environment variables (no longer visible via `docker inspect` or `/proc/1/environ`). `scripts/entrypoint.sh` already reads `/run/secrets/db_password` and constructs `DATABASE_URL` — this PR wires the compose layer to match.

### Changes (per issue's 6 steps)

1. **`docker-compose.{dev,prod}.yml`** — top-level `secrets:` stanza with `file: ./secrets/db_password.{dev,prod}`; `db_password` mounted into the `web` service.
2. **`web` service** — `secrets: [db_password]` added; `POSTGRES_USER` + `POSTGRES_DB` retained so `entrypoint.sh` can construct `DATABASE_URL`.
3. **`DATABASE_URL` removed** from web `environment:` — built at container start from the secret file; the existing env-var fallback in `entrypoint.sh` still works if the secret file is absent.
4. **`.gitignore`** — `secrets/db_password.{dev,prod}` ignored; `secrets/.gitkeep` and `secrets/db_password.example` tracked. (Per-file patterns used, not `secrets/` + negation — git cannot un-ignore files inside an ignored directory.)
5. **`scripts/deploy-remote-linux.sh`** — new secrets push block after the live `.env` push block: creates the remote `secrets/` dir, `changeme` pre-check, overwrite confirmation, stage-to-tmp + `install -m 600`.
6. **`README.md`** — documents the `cp secrets/db_password.example …` setup step and the new secret mechanism.

**Bonus fix:** `.github/workflows/docker-smoke.yml` adds a "Create test secret files" step so CI creates `secrets/db_password.{dev,prod}` before starting the stacks (without it the smoke build would fail — compose can't find the files declared in the `secrets:` stanza).

## Verification

- `bash -n scripts/deploy-remote-linux.sh` and `bash -n scripts/entrypoint.sh` — clean.
- `docker compose -f docker-compose.dev.yml config -q` and `-f docker-compose.prod.yml config -q` — both valid (run with throwaway `POSTGRES_*`/`SECRET_KEY` vars + stub secret files, since file-based secrets must exist at config time).
- `git check-ignore`: real secret files ignored; `secrets/db_password.example` and `secrets/.gitkeep` tracked.
- Python suite **not run** — no PostgreSQL test DB available in this environment; **zero Python files touched** (compose/script/workflow/docs/`.gitignore`/`secrets/` scaffolding only), so the suite is unaffected.

## Notes

- Touches `scripts/deploy-remote-linux.sh` in a separate region from open PR #741 (#646); additive block, expected to merge cleanly. Whichever lands first, the other should still apply.
- `CLAUDE.md` left untouched; the "Password encoding" note still applies (the `db` service still uses `POSTGRES_PASSWORD` for initial DB creation). A follow-up note that the web service now reads the password from the secret file may be worth adding — deferred to the router.

Closes #644

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_