### PR TITLE
ci(deploy): add OCI image labels via docker/metadata-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Extract OCI metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/glitchwerks/job-matcher
+          labels: |
+            org.opencontainers.image.revision=${{ github.event.workflow_run.head_sha }}
+            org.opencontainers.image.version=${{ github.event.workflow_run.head_sha }}
+
       - name: Build and push image (non-main — SHA tag only)
         if: ${{ github.event.workflow_run.head_branch != 'main' }}
         uses: docker/build-push-action@v5
@@ -49,6 +58,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/job-matcher:${{ github.event.workflow_run.head_sha }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -61,6 +71,7 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/job-matcher:latest
             ghcr.io/${{ github.repository_owner }}/job-matcher:${{ github.event.workflow_run.head_sha }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -291,6 +302,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Extract OCI metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/glitchwerks/job-matcher
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.sha }}
+
       - name: Build and push image (non-main — SHA + branch tags)
         if: ${{ github.ref_name != 'main' }}
         uses: docker/build-push-action@v5
@@ -300,6 +320,7 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/job-matcher:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/job-matcher:${{ steps.sha.outputs.short }}-${{ steps.branch_tag.outputs.safe }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -313,6 +334,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/job-matcher:latest
             ghcr.io/${{ github.repository_owner }}/job-matcher:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/job-matcher:${{ steps.sha.outputs.short }}-${{ steps.branch_tag.outputs.safe }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary

Bakes OCI labels into every image pushed by `deploy.yml`, so build provenance is readable directly from the image instead of requiring external workflow-run correlation (the gap confirmed by today's v1.3.0 image audit, where `docker inspect ... .Config.Labels` was `null`).

- Adds a `docker/metadata-action@v5` step (`id: meta`) before the build in **both** build jobs.
- Passes `labels: ${{ steps.meta.outputs.labels }}` to all four `docker/build-push-action` steps. **Tags and push behavior are unchanged** — only `labels:` lines were added.
- Labels baked: `org.opencontainers.image.revision` and `org.opencontainers.image.version`.

### Revision SHA — the subtle part

- **`workflow_run` (auto-deploy) job:** uses `github.event.workflow_run.head_sha` for the revision. In a `workflow_run` trigger, `github.sha` is the deploy workflow's own ref (`main`), **not** the commit being built — so using `github.sha` would stamp the wrong commit. `head_sha` matches the `checkout ref:` and the image tags already used in that job.
- **`workflow_dispatch` (manual) job:** uses `github.sha`, which is correctly the commit selected in the Run-workflow UI.

## Verification

- `actionlint .github/workflows/deploy.yml` — clean (exit 0).
- YAML parses cleanly.
- Diff confirmed: metadata step runs before each build-push; `steps.meta.outputs.labels` matches `id: meta`; no tag/push lines altered.

## Acceptance criteria (#740)

- [ ] After a deploy, `docker inspect <image> --format '{{json .Config.Labels}}'` shows a non-null `org.opencontainers.image.revision`.
- [ ] Revision matches the deployed commit SHA.
- [ ] No change to tags / push.

Closes #740

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_