### PR TITLE
ci(lint): add CRLF line-ending check for shell scripts and Dockerfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,13 @@ jobs:
       - name: ShellCheck
         run: shellcheck scripts/*.sh
 
+      - name: Check for CRLF line endings in shell scripts and Dockerfiles
+        run: |
+          if git ls-files '*.sh' '*.bash' 'Dockerfile*' | xargs -r grep -lU $'\r'; then
+            echo "::error::Files above contain CRLF line endings. See README Troubleshooting or .gitattributes."
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
## Summary

Adds a CI guardrail in the `lint` job (after ShellCheck) that fails the build if any tracked `*.sh`, `*.bash`, or `Dockerfile*` file contains CR bytes — defense-in-depth so CRLF can't slip past `.gitattributes` into `main`.

```yaml
- name: Check for CRLF line endings in shell scripts and Dockerfiles
  run: |
    if git ls-files '*.sh' '*.bash' 'Dockerfile*' | xargs -r grep -lU $'\r'; then
      echo "::error::Files above contain CRLF line endings. See README Troubleshooting or .gitattributes."
      exit 1
    fi
```

- `-U` (binary mode) matches `\r` literally across grep variants; `xargs -r` no-ops on an empty file list.
- On failure, the `::error::` annotation names the offending files and points at the README `## Troubleshooting` section and `.gitattributes`.

## Verification

- `actionlint .github/workflows/ci.yml` — clean; YAML parses.
- All 8 tracked files (`Dockerfile` + 7 `scripts/*.sh`) show `i/lf` via `git ls-files --eol` and have **no CR bytes in the committed blobs**.
- The **exact CI command** was run against the committed (LF) blobs → **0 matches**, confirming the new check is a no-op on current `main`. (Validated against committed blobs, not the local Windows working tree, which carries CRLF under `core.autocrlf=true` and would false-positive.)

Closes #623

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_