### PR TITLE
perf(#611): mtime-keyed cache for _get_search_validation_issues

### DIFF
--- a/services/provider_schemas.py
+++ b/services/provider_schemas.py
@@ -209,7 +209,7 @@ def _mtime(path: str) -> float:
         return 0.0
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=1)
 def _cached_validation(
     mtime_tuple: tuple[float, float],
     providers_path: str,
@@ -217,10 +217,17 @@ def _cached_validation(
 ) -> list[ValidationIssue]:
     """Load config files from disk and return validation issues.
 
-    This function is wrapped with :func:`functools.lru_cache`.  The cache key
-    is *(mtime_tuple, providers_path, config_path)* so any out-of-process
-    modification to either config file (including a ``/settings`` POST rewrite)
-    automatically busts the cache via the changed mtime.
+    This function is wrapped with :func:`functools.lru_cache` with
+    ``maxsize=1``.  There is effectively a single config/providers path-pair
+    in normal operation, so only the *current* mtime entry is needed.  A
+    bound of 1 ensures that each config edit evicts the previous entry rather
+    than accumulating an unbounded number of stale mtime entries over the
+    lifetime of a long-running Gunicorn worker.
+
+    The cache key is *(mtime_tuple, providers_path, config_path)* so any
+    out-of-process modification to either config file (including a
+    ``/settings`` POST rewrite) automatically busts the cache via the changed
+    mtime.
 
     Callers should **not** call this function directly; use
     :func:`_get_search_validation_issues` instead.

--- a/services/provider_schemas.py
+++ b/services/provider_schemas.py
@@ -37,6 +37,7 @@ import os
 import subprocess
 import sys
 import threading
+from functools import lru_cache
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from typing import Any, Callable, Optional
@@ -189,31 +190,53 @@ def _config_warnings(
 # ---------------------------------------------------------------------------
 
 
-def _get_search_validation_issues(
-    providers_path: Optional[str] = None,
-    config_path: Optional[str] = None,
-) -> list[ValidationIssue]:
-    """Return search-config validation issues for all enabled sources.
+def _mtime(path: str) -> float:
+    """Return the modification time of *path*, or ``0.0`` if it is absent.
 
-    Loads providers and config safely (returns empty list on any error) and
-    delegates to :func:`ingest.validate_search_config`.  Used by both the
-    ``/settings`` GET render and the ``/api/ingest/preflight`` endpoint so
-    the same validation logic is never duplicated.
+    Used as part of the cache key for :func:`_cached_validation`.  Returning
+    ``0.0`` for a missing file mirrors the existing graceful-fallback behaviour
+    in :func:`_get_search_validation_issues` — no extra error is raised.
 
     Args:
-        providers_path: Override path to ``providers.json``.  Defaults to
-            :data:`services.profile_store._PROVIDERS_PATH`.
-        config_path: Override path to ``config.json``.  Defaults to
-            :data:`services.profile_store._CONFIG_PATH`.
+        path: Filesystem path to stat.
+
+    Returns:
+        ``os.path.getmtime(path)`` when the file exists, ``0.0`` otherwise.
+    """
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return 0.0
+
+
+@lru_cache(maxsize=None)
+def _cached_validation(
+    mtime_tuple: tuple[float, float],
+    providers_path: str,
+    config_path: str,
+) -> list[ValidationIssue]:
+    """Load config files from disk and return validation issues.
+
+    This function is wrapped with :func:`functools.lru_cache`.  The cache key
+    is *(mtime_tuple, providers_path, config_path)* so any out-of-process
+    modification to either config file (including a ``/settings`` POST rewrite)
+    automatically busts the cache via the changed mtime.
+
+    Callers should **not** call this function directly; use
+    :func:`_get_search_validation_issues` instead.
+
+    Args:
+        mtime_tuple: 2-tuple of ``(providers_mtime, config_mtime)`` floats
+            used purely as a cache-busting key.  ``0.0`` encodes a missing
+            file (see :func:`_mtime`).
+        providers_path: Absolute path to ``providers.json``.
+        config_path: Absolute path to ``config.json``.
 
     Returns:
         List of :class:`ingest.ValidationIssue` objects.  Empty when all
-        enabled sources have complete search configuration.
+        enabled sources have complete search configuration or when the config
+        files cannot be loaded.
     """
-    if providers_path is None:
-        providers_path = _PROVIDERS_PATH
-    if config_path is None:
-        config_path = _CONFIG_PATH
     try:
         providers = load_providers(providers_path=providers_path)
     except CredentialError:
@@ -230,6 +253,40 @@ def _get_search_validation_issues(
         return []
 
     return validate_search_config(config, providers)
+
+
+def _get_search_validation_issues(
+    providers_path: Optional[str] = None,
+    config_path: Optional[str] = None,
+) -> list[ValidationIssue]:
+    """Return search-config validation issues for all enabled sources.
+
+    Results are mtime-keyed: repeated calls with unchanged config files are
+    served from an :func:`functools.lru_cache` in-memory cache.  Any
+    out-of-process modification to either file (including a ``/settings``
+    POST rewrite) busts the cache automatically via the changed mtime.
+
+    Delegates to :func:`_cached_validation` for the actual disk reads and
+    validation logic.  Used by both the ``/settings`` GET render and the
+    ``/api/ingest/preflight`` endpoint so the same validation logic is never
+    duplicated.
+
+    Args:
+        providers_path: Override path to ``providers.json``.  Defaults to
+            :data:`services.profile_store._PROVIDERS_PATH`.
+        config_path: Override path to ``config.json``.  Defaults to
+            :data:`services.profile_store._CONFIG_PATH`.
+
+    Returns:
+        List of :class:`ingest.ValidationIssue` objects.  Empty when all
+        enabled sources have complete search configuration.
+    """
+    if providers_path is None:
+        providers_path = _PROVIDERS_PATH
+    if config_path is None:
+        config_path = _CONFIG_PATH
+    mts = (_mtime(providers_path), _mtime(config_path))
+    return _cached_validation(mts, providers_path, config_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validation_cache.py
+++ b/tests/test_validation_cache.py
@@ -1,0 +1,173 @@
+"""tests/test_validation_cache.py — Unit tests for the mtime-keyed cache
+on :func:`services.provider_schemas._get_search_validation_issues`.
+
+Covered cases
+-------------
+* Cold call: first call reads from disk (validate_search_config invoked once).
+* Warm call: second call with unchanged mtimes hits the cache (no second read).
+* Cold-after-mutation: bumping a file's mtime busts the cache and triggers
+  a fresh read.
+
+No live database required — DB and credential calls are mocked out.
+All tests use tmp_path for isolation and reset the lru_cache between runs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import services.provider_schemas as _schemas_mod
+from ingest import ValidationIssue
+from services.provider_schemas import _get_search_validation_issues
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_providers(path: str) -> None:
+    """Write a minimal valid providers.json to *path*."""
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump({"provider_order": [], "llm": {}, "job_sources": {}}, fh)
+
+
+def _write_config(path: str) -> None:
+    """Write a minimal valid config.json to *path*."""
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "search": {
+                    "country": "us",
+                    "what": "developer",
+                    "where": "Miami",
+                    "results_per_page": 50,
+                    "max_pages": 3,
+                },
+                "scoring": {"threshold": 7.0},
+            },
+            fh,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cache tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidationIssuesCache:
+    """Mtime-keyed cache on _get_search_validation_issues.
+
+    Each test resets the lru_cache via _cached_validation.cache_clear() so
+    tests do not interfere with each other.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        """Clear the lru_cache before and after every test in this class."""
+        _schemas_mod._cached_validation.cache_clear()
+        yield
+        _schemas_mod._cached_validation.cache_clear()
+
+    def test_cold_call_reads_from_disk(self, tmp_path):
+        """First call invokes validate_search_config exactly once."""
+        providers_path = str(tmp_path / "providers.json")
+        config_path = str(tmp_path / "config.json")
+        _write_providers(providers_path)
+        _write_config(config_path)
+
+        fake_issue = ValidationIssue(
+            source_key="adzuna", missing_fields=["country"]
+        )
+
+        with patch.object(
+            _schemas_mod, "validate_search_config", return_value=[fake_issue]
+        ) as mock_validate:
+            result = _get_search_validation_issues(
+                providers_path=providers_path,
+                config_path=config_path,
+            )
+
+        assert mock_validate.call_count == 1, (
+            "Expected validate_search_config to be called once on a cold call"
+        )
+        assert result == [fake_issue]
+
+    def test_warm_call_does_not_re_read(self, tmp_path):
+        """Second call with unchanged file mtimes returns cached result."""
+        providers_path = str(tmp_path / "providers.json")
+        config_path = str(tmp_path / "config.json")
+        _write_providers(providers_path)
+        _write_config(config_path)
+
+        fake_issue = ValidationIssue(
+            source_key="adzuna", missing_fields=["country"]
+        )
+
+        with patch.object(
+            _schemas_mod, "validate_search_config", return_value=[fake_issue]
+        ) as mock_validate:
+            result_first = _get_search_validation_issues(
+                providers_path=providers_path,
+                config_path=config_path,
+            )
+            result_second = _get_search_validation_issues(
+                providers_path=providers_path,
+                config_path=config_path,
+            )
+
+        assert mock_validate.call_count == 1, (
+            "Expected validate_search_config to be called only once across "
+            "two calls with unchanged file mtimes (cache miss prevented second read)"
+        )
+        assert result_first == result_second
+
+    def test_cold_after_mtime_mutation_re_reads(self, tmp_path):
+        """Bumping a config file's mtime busts the cache and triggers a re-read."""
+        providers_path = str(tmp_path / "providers.json")
+        config_path = str(tmp_path / "config.json")
+        _write_providers(providers_path)
+        _write_config(config_path)
+
+        first_issue = ValidationIssue(
+            source_key="adzuna", missing_fields=["country"]
+        )
+        second_issue = ValidationIssue(
+            source_key="adzuna", missing_fields=["what"]
+        )
+
+        with patch.object(
+            _schemas_mod,
+            "validate_search_config",
+            side_effect=[[first_issue], [second_issue]],
+        ) as mock_validate:
+            result_first = _get_search_validation_issues(
+                providers_path=providers_path,
+                config_path=config_path,
+            )
+
+            # Advance the config file's mtime by 1 second to simulate a
+            # /settings POST rewrite or out-of-process edit.
+            stat = os.stat(config_path)
+            new_atime = stat.st_atime + 1.0
+            new_mtime = stat.st_mtime + 1.0
+            os.utime(config_path, (new_atime, new_mtime))
+
+            result_second = _get_search_validation_issues(
+                providers_path=providers_path,
+                config_path=config_path,
+            )
+
+        assert mock_validate.call_count == 2, (
+            "Expected validate_search_config to be called twice: once for the "
+            "cold call, once after the mtime bump busted the cache"
+        )
+        assert result_first == [first_issue]
+        assert result_second == [second_issue]


### PR DESCRIPTION
## Summary

Caches `_get_search_validation_issues()` so `providers.json` and `config.json` are no longer read from disk on every `GET /settings` render and `GET /api/ingest/preflight` call.

- The function had moved during the `web/` refactor — it now lives in `services/provider_schemas.py:192`; call sites are `web/settings.py` (`/settings`) and `web/ingest.py` (`/api/ingest/preflight`).
- Adds `_mtime(path)` (returns `os.path.getmtime`, `0.0` on `OSError` — preserves the existing missing-file behavior) and an `@lru_cache(maxsize=1)` `_cached_validation(...)` keyed on `(providers_mtime, config_mtime, providers_path, config_path)`.
- Any out-of-process rewrite (e.g. a `/settings` POST) changes the mtime tuple → cache miss → fresh read, with no explicit invalidation logic.
- `maxsize=1` (not unbounded): the path-pair is effectively fixed, so only the mtime varies and only the current entry is ever needed — bounding it prevents stale mtime entries accumulating in a long-running Gunicorn worker.
- Callers iterate the result read-only, so the cached list is safe to share (no copy needed).

## Verification

- **Baseline** (`355dac1`): 2118 passed, 1 skipped, `ruff` clean.
- **Post-change**: 2121 passed, 1 skipped (+3 new tests), `ruff` clean. No named failures.
- New `tests/test_validation_cache.py` (independently re-run — 3 passed): cold call reads disk once; warm call hits cache (no re-read, holds with `maxsize=1`); cold-after-mtime-mutation evicts and re-reads.
- Existing `/settings` and `/api/ingest/preflight` route tests pass unchanged.

Closes #611

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_