### PR TITLE
docs(2.0): Cycle 0+1 foundation spec + architecture decisions

### DIFF
--- a/docs/superpowers/specs/2026-05-29-job-matcher-2.0-architecture-decisions.md
+++ b/docs/superpowers/specs/2026-05-29-job-matcher-2.0-architecture-decisions.md
@@ -1,0 +1,223 @@
+# job-matcher 2.0 — Architecture Decision Record
+
+> **Status:** LOCKED 2026-05-29 (brainstorming session + OpenDesign handoff reconciliation).
+> **Scope:** cross-cutting architectural decisions for the 2.0 initiative; they constrain every cycle.
+> **Companion:** `2026-05-29-job-matcher-2.0-roles-foundation-design.md` (Cycle 0+1 spec).
+> **Tracking:** Epic glitchwerks/job-matcher#751 · milestone #12 · cycles #747–#750.
+>
+> These decisions answer a series of "is the core architecture still correct, and what should change
+> *now* while the schema/UI are being reset?" questions. Where a decision overrides the existing
+> CLAUDE.md § Key design decisions, that is called out explicitly.
+
+---
+
+## Decision index
+
+| ADR | Decision | Affects |
+|---|---|---|
+| 001 | All config in PostgreSQL (departs from flat-file profile) | Cycle 0 |
+| 002 | Keep no-ORM (psycopg2); split `db.py` into a `db/` package | Cycle 0 |
+| 003 | Money as `NUMERIC`/minor-units, not `REAL`; normalize currency+period | Cycle 0 |
+| 004 | `TIMESTAMPTZ` for all timestamps | Cycle 0 |
+| 005 | `JSONB` for JSON columns, not JSON-in-`TEXT` | Cycle 0 |
+| 006 | ID strategy: serial-int internal PKs; stable slug keys where cross-referenced | Cycle 0 |
+| 007 | Single-user; multi-user deferred to v3 (no tenancy now) | all |
+| 008 | Keep HTMX; make it reversible via an API-first service layer | Cycle 2 |
+| 009 | Rendering discipline made structural: one render chokepoint + CI contract tests | Cycle 2 |
+| 010 | Explicit write contract: PATCH semantics (absent/null/value); never echo secrets | Cycle 0/2 |
+| 011 | Secrets boundary: credentials in file/secret-store; DB holds routing/refs only | Cycle 0/2 |
+| 012 | Migrations: stay hand-rolled for Cycle 0; adopt tooling only if pulled | Cycle 0 |
+| 013 | Payload validation (pydantic) with the Cycle 2 API, not upfront | Cycle 2 |
+| 014 | Resume file storage = local mounted volume, no object store | Cycle 3 |
+| 015 | SSE live ingest stream: document proxy no-buffer; no new service | Cycle 2 |
+
+---
+
+## ADR-001 — All configuration moves into PostgreSQL
+
+**Context.** Today the candidate/search config lives in flat files (`config/profile.json`,
+`config/config.json`); CLAUDE.md § Key design decisions chose the flat file because it was "edited
+manually as a whole unit; easier to version-control." 2.0 introduces Roles (need stable IDs + FK from
+the `matches` join + live UI editing) and Job Preferences.
+
+**Decision.** Profile, Job Preferences, Roles, Skills, and `matches` all become PostgreSQL tables.
+The `/profile` and `/settings` surfaces become DB-backed CRUD. A one-time migration seeds the DB from
+the existing flat files (see Cycle 0 spec §3.3). **Overrides the flat-file decision deliberately.**
+
+**Consequences.** Enables relational integrity for many-to-many scoring and role lifecycle; removes
+hand-edited JSON onboarding (replaced by UI — see ADR-009/deployment note). Credentials are the
+exception (ADR-011).
+
+## ADR-002 — Keep no-ORM (psycopg2); split `db.py` into a `db/` package
+
+**Context.** CLAUDE.md chose "PostgreSQL, no ORM" because "schema is small and stable." 2.0 makes it
+larger and relational (5 new tables, a join, sparse-override resolution, combined-view joins). `db.py`
+already hand-serializes JSON and is 640+ lines (`db.py:639` `insert_listing`).
+
+**Decision.** Stay on psycopg2 (no ORM). Manage growth by **splitting `db.py` into a `db/` package
+by entity** (`db/profile.py`, `db/roles.py`, `db/matches.py`, …) with a thin row→dict mapping helper.
+SQLAlchemy Core (query builder, not the full ORM) is the documented fallback **only if** hand-written
+SQL becomes error-prone — not adopted pre-emptively (YAGNI).
+
+**Consequences.** Avoids ORM dependency + migration; risk is module sprawl, mitigated by the package split.
+
+## ADR-003 — Money as `NUMERIC`/minor-units, not `REAL`
+
+**Context.** `listings.salary_min/max` are `REAL` (`db.py:339-340`). 2.0 adds salary math
+(delta-vs-base, range midpoints), where float drift is a latent bug.
+
+**Decision.** Store money as `NUMERIC` (or integer minor units) with explicit `currency` + `period`
+(`base_salary`/`target_salary` carry `{amount, currency, period}`). Normalize currency/period before
+computing deltas; ranges use the midpoint. No-salary postings are a red flag, never an auto-drop.
+
+**Consequences.** Correct money math; a column-type choice that is free now, a data migration later.
+
+## ADR-004 — `TIMESTAMPTZ` for all timestamps
+
+**Context.** The schema is inconsistent — `created_at/fetched_at/posted_at/opened_at` are `TEXT`
+(`db.py:346-362`) while `ingest_runs` uses `TIMESTAMPTZ` (`db.py:424-425`). Freshness gates
+(hours filter, `max_days_old`) depend on correct, TZ-aware comparison.
+
+**Decision.** All timestamp columns are `TIMESTAMPTZ`. Standardize during the Cycle 0 schema build.
+
+**Consequences.** Correct sorting/filtering; removes a class of TEXT-timestamp footguns.
+
+## ADR-005 — `JSONB` for JSON columns, not JSON-in-`TEXT`
+
+**Context.** `db.py` hand-`json.dumps`/`loads` arrays into `TEXT`. 2.0 adds queryable arrays
+(`role.applicable_skills`, `matches`, `overrides`, `preferences.locations`).
+
+**Decision.** Use `JSONB` for these columns. Enables native validation + GIN-indexed containment
+queries (combined view, "roles with skill X") that `TEXT` cannot.
+
+**Consequences.** Better query power and integrity; trivial now, a conversion migration later.
+
+## ADR-006 — ID strategy
+
+**Decision.** Internal primary keys are serial integers (consistent with `listings.id`). Use stable
+**slug-style string IDs only where an entity is cross-referenced by humans or other rows** — Skills
+(referenced by `role.applicable_skills`) and Roles (referenced by `matches.role_id`, `default_resume_id`).
+Don't mix conventions ad hoc.
+
+**Consequences.** Predictable references; aligns with single-user (ADR-007) — no UUIDs needed.
+
+## ADR-007 — Single-user; multi-user deferred to v3
+
+**Context.** `api-surface.md §6.4` flags single-user-vs-multi-user as the most expensive
+retrofit-if-wrong decision (everything would re-root under an account).
+
+**Decision.** **Single-user.** Candidate and Job Preferences are singletons. **Multi-user is a v3
+concern** — do NOT build account scoping, auth, or tenancy now. The value is the explicit decision,
+not a feature. (Pushed back on building a speculative `owner_id` seam — omitted as YAGNI.)
+
+**Consequences.** Simplest model; a future v3 multi-user effort is a known, accepted re-root cost.
+
+## ADR-008 — Keep HTMX; make it reversible via an API-first service layer
+
+**Context.** CLAUDE.md chose "HTMX, no JS framework" for a "read-mostly UI with two write actions."
+2.0's UI is far richer (CRUD across many entities, inspector, combined view, live SSE stream), so the
+original premise no longer holds. HTMX's front/back contract is inherently implicit (template names,
+swap targets, trigger strings) — weaker than a typed-API + component framework.
+
+**Decision.** **Keep HTMX** (the OpenDesign Shell-B prototype validates it; a framework would add
+build tooling + a JSON API + a second render model). De-risk the choice by building the Cycle 2
+backend as a **resource/service layer (JSON-capable) with HTMX as a thin server-side renderer over the
+same layer.** A later pivot to a JS framework then reuses the API and discards only the Jinja layer —
+bounded blast radius, decision stays reversible.
+
+**Consequences.** No build tooling now; the service layer is the seam that keeps the option open and
+is also the chokepoint for ADR-009/010.
+
+## ADR-009 — Rendering discipline made structural (not a checklist)
+
+**Context.** The v1 feed had a documented front/back rendering bug (`glitchwerks/job-matcher-pr#223`,
+fixed by `#224`) that introduced a dual render-path (`/` vs `/feed/fragment`), leaving open coupling
+debt: duplicated card markup (#580), filters lost on refresh (#581), duplicated query parsing (#582,
+`web/feed.py:77-94` vs `:136-153`). "Discipline" as a doc checklist is fragile — newcomers don't see
+it, shortcuts bypass it.
+
+**Decision.** Make it **structural + tested**, not remembered:
+1. **One render chokepoint** — a single feed-render service/function is the *only* way to produce feed
+   HTML; one shared card partial; one shared query parser covering new `role`/`combined`/`state` dims.
+2. **CI contract tests** — full-page vs fragment markup byte-identical for the same query; filters/role/
+   view survive a refresh; card markup string exists in exactly one template.
+Supersedes #580/#581/#582 (close as superseded when Cycle 2 lands — tracked in #749).
+
+**Consequences.** Violations fail CI instead of shipping; converts ~80% of the fragility from human
+memory to mechanical enforcement.
+
+## ADR-010 — Explicit write contract: PATCH semantics; never echo secrets
+
+**Context.** Full-page form POSTs over form-encoding can't distinguish "cleared this field" from
+"unchanged / absent" — the LLM/Sources settings pages needed sentinel workarounds. 2.0 makes this
+central: `Role.overrides` is a **sparse map** (absent = inherit, present = override, removed = revert)
+— the exact absent/null/value trichotomy, now a core modeling primitive.
+
+**Decision.** Writes use **explicit partial-update (PATCH) semantics** with a typed payload where
+**absent = no change, explicit null = clear, value = set** (JSON expresses this; form-encoding can't).
+Merge policy defined **once per resource** in the service layer and tested. `Role.overrides` stores
+only overridden keys; "revert to shared" deletes the key. Secrets are **never echoed** to the client
+(presence indicator only); omit = unchanged, explicit clear = remove, value = rotate.
+
+**Consequences.** Eliminates the cleared-vs-empty bug structurally; makes the override UX correct;
+drives scoped PATCH endpoints (HTMX still fine) rather than one giant full-form POST.
+
+## ADR-011 — Secrets boundary
+
+**Context.** Keys live in `config/providers.json` (LLM + source creds) with env overrides; the DB
+password moved to Docker file-based secrets (commit #742). 2.0 moves `models`/`sources` *config* to DB.
+
+**Decision.** **Keep credentials OUT of the DB.** DB stores operational/routing config and references
+providers **by name**; actual keys stay in file/Docker-secret/env (resolution order: env/Docker-secret
+→ `providers.json` fallback). A provider's full credential bundle stays together in the secret store
+(no id-in-DB / key-in-file split). No encryption-at-rest, no external secret-store dependency (YAGNI).
+
+**Consequences.** DB compromise ≠ key compromise; keys never in backups/dumps/logs; consistent with #742.
+
+## ADR-012 — Migrations stay hand-rolled for Cycle 0
+
+**Decision.** Continue the existing idempotent pattern (`CREATE TABLE IF NOT EXISTS` /
+`ADD COLUMN IF NOT EXISTS` in `db.init_db()`, `db.py:368-405`). Adopt a migration tool (Alembic/yoyo)
+**only if** the flat-file→DB migration or later schema changes prove error-prone — a watch item, not a
+pre-emptive adoption.
+
+**Consequences.** No new tooling now; revisit if hand-rolled migration against the production DB hurts.
+
+## ADR-013 — Payload validation adopted with the Cycle 2 API
+
+**Decision.** Introduce a validation layer (pydantic; precedent in `services/provider_schemas.py`)
+**alongside** the Cycle 2 resource/PATCH API — it provides the contract + validation + the absent/null/
+value distinction in one place. Not an upfront standalone project.
+
+## ADR-014 — Resume file storage = local mounted volume
+
+**Decision.** `Resume.content_ref` (Cycle 3) points at files on a **local Docker-mounted volume**, not
+object storage / S3. Add the volume to the backup set. For a single-user tool this is the right weight;
+no blob-store dependency.
+
+## ADR-015 — SSE live ingest stream: document, don't add a service
+
+**Decision.** The Cycle 2 live ingest stream uses SSE over the existing WSGI server (waitress in
+Docker per CLAUDE.md § Deployment). **Document the required proxy setting** (`proxy_buffering off` /
+streaming) and note the per-connection worker cost. No queue, worker container, or message broker —
+single-user concurrency does not warrant them.
+
+---
+
+## Deployment posture (summary)
+
+2.0 adds **no new infra services** — the topology stays Postgres + Flask + ingest CLI in the existing
+Docker stack. Added surface is UX (a first-run/empty-state to replace hand-edited JSON onboarding —
+helped by the existing PDF import, `services/pdf_import.py`), one resume volume (ADR-014), and one SSE
+proxy note (ADR-015). New-user setup time is unchanged (acquiring API keys remains the real cost);
+complexity moves from ~5 to ~5–6 on a 10-point scale. Update README onboarding steps when these land.
+
+## References
+
+- Current schema/types: `db.py:339-340` (REAL salary), `:346-362` (TEXT timestamps), `:368-405`
+  (migration pattern + JSON-in-TEXT), `:424-425` (TIMESTAMPTZ precedent), `:639` (`insert_listing`).
+- Feed render coupling: `web/feed.py:77-94` / `:136-153` (duplicated parsing); history
+  `glitchwerks/job-matcher-pr#223` / `#224`; open `glitchwerks/job-matcher#580` / `#581` / `#582`.
+- Secrets direction: commit #742 (Docker file-based secrets); CLAUDE.md § Config & profile.
+- Open API decisions: `api-surface.md §6` (OpenDesign handoff, captured 2026-05-29).
+- Tracking: epic #751, milestone #12, cycles #747–#750.

--- a/docs/superpowers/specs/2026-05-29-job-matcher-2.0-architecture-decisions.md
+++ b/docs/superpowers/specs/2026-05-29-job-matcher-2.0-architecture-decisions.md
@@ -1,6 +1,7 @@
 # job-matcher 2.0 — Architecture Decision Record
 
-> **Status:** LOCKED 2026-05-29 (brainstorming session + OpenDesign handoff reconciliation).
+> **Status:** REVISED v2 2026-05-29 — reviewed on PR #752 (`project-reviewer` + `inquisitor`); ADR-003/004/005/006/009
+> updated below; re-review pending. (v1 "LOCKED" was premature.)
 > **Scope:** cross-cutting architectural decisions for the 2.0 initiative; they constrain every cycle.
 > **Companion:** `2026-05-29-job-matcher-2.0-roles-foundation-design.md` (Cycle 0+1 spec).
 > **Tracking:** Epic glitchwerks/job-matcher#751 · milestone #12 · cycles #747–#750.
@@ -30,6 +31,25 @@
 | 013 | Payload validation (pydantic) with the Cycle 2 API, not upfront | Cycle 2 |
 | 014 | Resume file storage = local mounted volume, no object store | Cycle 3 |
 | 015 | SSE live ingest stream: document proxy no-buffer; no new service | Cycle 2 |
+
+---
+
+## v2 changes (from the PR #752 review — `project-reviewer` + `inquisitor`)
+
+The aggressive review of v1 produced 3 blockers + a contradiction, all resolved here and in the design spec:
+
+- **B1 — lifecycle vs `description_source` collision** → design §2.5 renames the new axis to
+  `lifecycle` (`discovered`\|`scored`), orthogonal to the untouched `description_source`. (design D11)
+- **B2 — dedup defeated the many-to-many fan-out** → design §4.1 makes dedup match-aware
+  (`(listing, role)`), upsert-then-check. (design D12)
+- **B3 — non-atomic migration on the autocommit pool** → design §3.3 wraps the seed in one explicit
+  transaction gated by a `schema_version` sentinel + a post-commit assertion. (design D13)
+- **PK contradiction** → ADR-006 (above) resolves to serial-int PK + separate UNIQUE `slug`; FKs target
+  the int. (design D16)
+- Plus resolved concerns: Cycle-1 feed reads a `MAX(matches.score)` roll-up (design D14); roles are
+  soft-delete-only to remove the mid-run FK crash path (design D15); B-mode worst case = K scoring calls,
+  accepted + budget-logged (design D17); ADR-003/004/005 scoped to new tables only (note under ADR-005);
+  ADR-009 chokepoint + contract tests specified concretely and #580/#581/#582 stay open until they exist.
 
 ---
 
@@ -90,16 +110,31 @@ computing deltas; ranges use the midpoint. No-salary postings are a red flag, ne
 **Decision.** Use `JSONB` for these columns. Enables native validation + GIN-indexed containment
 queries (combined view, "roles with skill X") that `TEXT` cannot.
 
-**Consequences.** Better query power and integrity; trivial now, a conversion migration later.
+**Consequences.** Better query power and integrity on the new tables.
 
-## ADR-006 — ID strategy
+> **Scope note for ADR-003/004/005 (REVISED v2 — resolves the ADR-012 tension the `inquisitor` raised).**
+> These type choices apply to **new tables/columns only** (Profile/Role/JobPreferences/Match, `base_salary`,
+> `target_salary`, the JSONB arrays). **Existing `listings` columns (`REAL` salary, `TEXT` timestamps,
+> `TEXT`-JSON) are explicitly OUT OF SCOPE for Cycle 0** — they are not converted in-place. Mixed-type
+> reads are handled by per-table row mappers (design §3.2). IF a future cycle ever converts the legacy
+> `listings` columns, that lossy in-place `ALTER ... USING` migration is exactly the "error-prone" trigger
+> ADR-012 names — and would adopt migration tooling at that point. No lossy conversion of populated legacy
+> columns ships in 2.0, so the deferred-conversion risk the review flagged does not materialize here.
 
-**Decision.** Internal primary keys are serial integers (consistent with `listings.id`). Use stable
-**slug-style string IDs only where an entity is cross-referenced by humans or other rows** — Skills
-(referenced by `role.applicable_skills`) and Roles (referenced by `matches.role_id`, `default_resume_id`).
-Don't mix conventions ad hoc.
+## ADR-006 — ID strategy (REVISED v2 — resolves the PK/slug contradiction)
 
-**Consequences.** Predictable references; aligns with single-user (ADR-007) — no UUIDs needed.
+**Context.** v1 was self-contradictory: this ADR said "serial-int PKs" while the data-model §2 used a
+string slug `id` as the `matches.role_id` FK target. `roles.id` cannot be both. The `inquisitor` flagged
+this as the FK the whole join hangs on.
+
+**Decision (resolved).** **The PK is the serial integer `id`, and it is the FK target.** A separate
+**`slug TEXT UNIQUE`** column carries the human-stable display/URL key — it is **never** an FK target.
+- `skills.id` (serial int) is what `roles.applicable_skills` stores (an `int[]`).
+- `roles.id` (serial int) is what `matches.role_id` and `roles.default_resume_id` reference.
+- `slug` is mutable-but-stable for display; renaming a skill/role changes `name`, not `slug`, and never
+  touches an FK. Design spec §2.2/§2.3/§2.5/§3.2 are aligned to this (D16).
+
+**Consequences.** One unambiguous FK target; predictable references; aligns with single-user (no UUIDs).
 
 ## ADR-007 — Single-user; multi-user deferred to v3
 
@@ -136,15 +171,27 @@ debt: duplicated card markup (#580), filters lost on refresh (#581), duplicated 
 `web/feed.py:77-94` vs `:136-153`). "Discipline" as a doc checklist is fragile — newcomers don't see
 it, shortcuts bypass it.
 
-**Decision.** Make it **structural + tested**, not remembered:
-1. **One render chokepoint** — a single feed-render service/function is the *only* way to produce feed
-   HTML; one shared card partial; one shared query parser covering new `role`/`combined`/`state` dims.
-2. **CI contract tests** — full-page vs fragment markup byte-identical for the same query; filters/role/
-   view survive a refresh; card markup string exists in exactly one template.
-Supersedes #580/#581/#582 (close as superseded when Cycle 2 lands — tracked in #749).
+**Decision.** Make it **structural + tested**, not remembered. Concretely (REVISED v2 — the `inquisitor`
+charged that v1 stated this as a checklist, not a testable contract):
+1. **One render chokepoint** — a single function is the *only* way to produce feed HTML. Indicative
+   signature: `render_feed(query: FeedQuery, *, fragment: bool) -> str` (full page wraps the same body
+   the fragment returns). One shared `_feed_cards.html` partial `{% include %}`d by both; one shared
+   `parse_feed_query(request) -> FeedQuery` covering the new `role` / `combined` / `lifecycle` dims.
+2. **Literal CI contract tests:**
+   - `test_feed_fullpage_and_fragment_card_markup_identical` — for a fixed `FeedQuery` fixture, the
+     `#feed-content` subtree of `GET /` equals the entire body of `GET /feed/fragment` (byte-for-byte
+     after normalizing whitespace).
+   - `test_feed_card_markup_single_source` — the card markup string/macro appears in exactly one
+     template file (grep assertion).
+   - `test_fragment_refresh_preserves_query` — a fragment fetch with filters/role/view params returns the
+     same filtered set as the full page with those params.
 
-**Consequences.** Violations fail CI instead of shipping; converts ~80% of the fragility from human
-memory to mechanical enforcement.
+**Do NOT close #580/#581/#582 as "superseded" on the strength of this ADR** (the `inquisitor` flagged
+this as laundering unsolved debt). Close them only when the chokepoint + the three tests above **exist in
+code** (Cycle 2, #749).
+
+**Consequences.** Violations fail CI instead of shipping; converts the fragility from human memory to
+mechanical enforcement — but only once the tests land, which is why the issues stay open until then.
 
 ## ADR-010 — Explicit write contract: PATCH semantics; never echo secrets
 

--- a/docs/superpowers/specs/2026-05-29-job-matcher-2.0-roles-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-29-job-matcher-2.0-roles-foundation-design.md
@@ -1,6 +1,6 @@
 ---
 title: job-matcher 2.0 — Cycle 0 (Foundation) + Cycle 1 (Roles ingest/scoring)
-status: revised-v2 — re-review pending
+status: revised-v3 — review complete
 touches:
   - db.py
   - ingest.py
@@ -8,6 +8,7 @@ touches:
   - web/**
   - services/**
   - plugins/sources/**
+  - job_sources/base.py
   - templates/**
   - conftest.py
   - tests/**
@@ -16,9 +17,10 @@ tracking: { epic: 751, milestone: 12, cycles: [747, 748] }
 
 # job-matcher 2.0 — Cycle 0 (Foundation) + Cycle 1 (Roles ingest/scoring) — design spec
 
-> **Status:** REVISED v2 — 2026-05-29. v1 was reviewed on PR glitchwerks/job-matcher#752 by
-> `project-reviewer` + `inquisitor` (aggressive pass); this revision resolves the 3 blockers + the PK
-> contradiction + the concerns they raised. **Not yet re-reviewed.** ("LOCKED" was premature in v1.)
+> **Status:** REVISED v3 — 2026-05-29, **review complete**. v1 → reviewed (`project-reviewer` +
+> `inquisitor`) → v2 fixed the 3 blockers + PK → v2 re-reviewed (both confirmed those PASS) → v3 fixes
+> the 3 *new* blockers the v2 fixes exposed (N1 dedup `RETURNING` idiom, N2 best-fit Match-row selection,
+> N3 cross-process purge lock) + the concern set. Review thread on PR glitchwerks/job-matcher#752.
 > **Tracking:** Epic #751 · milestone #12 · Cycle 0 #747 · Cycle 1 #748.
 > **Scope:** Cycles 0 and 1 only. Cycle 2 (API + UI, #749) and Cycle 3 (Resumes, #750) get their own specs.
 
@@ -215,8 +217,12 @@ Resume / Application — DEFERRED to Cycle 3 (applied_resume_id is link-only)
   `active=false` = paused (temporary); `archived=true` = retired (permanent-ish, hidden). Archived roles
   are excluded from ingest and the UI but their historical Matches stay valid.
 - **Hard purge** (truly delete a role + its Matches, `ON DELETE CASCADE`) is a separate explicit Admin
-  action, **gated on no ingest running** (checked via `ingest_control._ingest_running()`). Not exposed as
-  routine UI delete.
+  action, **gated by a cross-process DB signal — NOT `ingest_control._ingest_running()`** (which only
+  sees web-spawned subprocesses and is blind to `python ingest.py` cron/manual runs, the primary entry
+  point — N3). Use a **PostgreSQL advisory lock** (`pg_advisory_lock`) that both the ingest run
+  (acquired at run start, released at finish) and the hard-purge acquire; the purge refuses if it can't
+  get the lock. Equivalently/additionally, check `ingest_runs` for a `status='running'` row (written by
+  both CLI and web via `db.create_ingest_run`, `db.py:1207`). Not exposed as routine UI delete.
 - **Run-start snapshot + staleness.** Ingest snapshots active roles at run start (§4.7). If a role's
   `updated_at` changes between snapshot and a Match write for that role, ingest logs a staleness warning
   (the run used the snapshot config; the next run picks up edits). No mid-run config reload.
@@ -247,7 +253,8 @@ Resume / Application — DEFERRED to Cycle 3 (applied_resume_id is link-only)
 | `roles` | collection, `id SERIAL PK`, `slug UNIQUE` | Role (2.3); JSONB for `prefilter/scoring_notes/anti_preferences/applicable_skills/overrides`; `active/archived/updated_at` |
 | `matches` | join, PK `(listing_id, role_id)` | Match (2.5); FK `listing_id`→`listings.id` ON DELETE CASCADE, `role_id`→`roles.id`; indexes on `role_id`, `listing_id` |
 
-`listings` additions: `lifecycle TEXT NOT NULL DEFAULT 'scored'`, `applied_resume_id INTEGER NULL`.
+`listings` additions: **`lifecycle TEXT NULL`** (nullable at `ADD COLUMN` — NOT `DEFAULT 'scored'`; see
+§3.3 for why) and `applied_resume_id INTEGER NULL`.
 
 **Table-creation order (was a v1 CONCERN):** `init_db()` must create parents before children —
 `skills`, `roles`, `job_preferences`, `profile` before `matches` (which FKs `roles` + `listings`).
@@ -273,27 +280,44 @@ Run inside `db.init_db()`, gated by `schema_version`. The seed runs in **one exp
 (`raw.autocommit=False` for the block; `conn.commit()` once at the end — the seam at `db.py:297-308`):
 
 ```
+# prereq (schema creation, §3.2): ADD COLUMN lifecycle TEXT NULL   (nullable, NO default — see below)
 if schema_version < 1:
-  BEGIN
-    1. Seed Profile from config/profile.json
-         (skills: description→name + assign slug + serial id; drop `active`;
-          education/anti_preferences→baseline/scoring_notes→baseline; seniority/preferred_industries→defaults;
-          location.center→current_location.label; base_salary/residency/current_role → empty defaults)
-    2. Seed JobPreferences from config.json (radius_km from search.distance/location.radius_km;
-         max_days_old; salary_min → salary_mode='floor', floor_amount=salary_min;
+  conn._conn.autocommit = False                 # explicit txn on this checked-out connection
+  try:
+    BEGIN
+      1. Seed Profile (skills: description→name + slug + serial id, drop `active`; education/
+         anti_preferences/scoring_notes → baselines; seniority/preferred_industries → defaults;
+         location.center → current_location.label; base_salary/residency/current_role → empty defaults)
+      2. Seed JobPreferences (radius_km; max_days_old; salary_min → salary_mode='floor'+floor_amount;
          require_contract_* → job_types/work_arrangement per the table below)
-    3. Seed one Role from config.json search (search_what, prefilter, threshold, active=true,
-         archived=false, applicable_skills = ALL skill ids → behavior unchanged, empty additions/overrides)
-    4. Backfill matches: one Match per seen=1 listing against the seeded Role (copy score/verdict/
-         skills/concerns/model/tokens); set listing.lifecycle='scored'.
-         seen=0 listings (score failed) → lifecycle='discovered' (O3 RESOLVED) so Cycle-1 retry re-scores.
-    5. INSERT schema_version (1, now())
-  COMMIT   // all-or-nothing: an interrupted run rolls back; re-run repeats cleanly
-  ASSERT  (post-commit) COUNT(matches) == COUNT(listings WHERE seen=1)   // log + alert if mismatch
+      3. Seed one Role (search_what/prefilter/threshold; active=true, archived=false;
+         applicable_skills = ALL skill ids → behavior unchanged; empty additions/overrides)
+      4. Backfill matches: one Match per seen=1 listing vs the seeded Role (copy score/verdict/skills/
+         concerns/model/tokens).
+         Set lifecycle for ALL rows IN THIS TXN: seen=1 → 'scored'; seen=0 → 'discovered' (O3).
+         Then ALTER TABLE listings ALTER COLUMN lifecycle SET NOT NULL   # safe: every row now populated
+      5. ASSERT COUNT(matches) == COUNT(listings WHERE seen=1); on mismatch RAISE → rolls the txn back
+         (the assertion is INSIDE the txn — a corrupt migration is NEVER marked done)
+      6. INSERT schema_version (1, now())
+    COMMIT       # all-or-nothing: interrupted run rolls back; re-run repeats cleanly
+  finally:
+    conn._conn.autocommit = True                # RESTORE before the pool recycles this connection
 ```
 
-The guard is **`schema_version`**, not "profile row exists" — an interrupted run (no commit) leaves
-`schema_version` unset, so the next `init_db()` re-runs the whole seed cleanly. No half-migrated lock.
+Why these specifics (from the v2 review):
+- **`lifecycle` is added nullable, then backfilled + `SET NOT NULL` inside the txn** — not
+  `ADD COLUMN … DEFAULT 'scored'` (which would stamp `seen=0` rows `'scored'` via DDL outside the txn;
+  a crash before step 4 would leave them permanently mislabeled).
+- **The guard is `schema_version`, not "profile row exists"** — an interrupted run (no commit) leaves
+  `schema_version` unset, so the next `init_db()` re-runs the whole seed cleanly. No half-migrated lock.
+- **The consistency assertion is INSIDE the txn** (before the `schema_version` insert) — a mismatch
+  rolls everything back rather than committing a corrupt state and marking it done-forever.
+- **`autocommit` is restored to `True` in a `finally`** — the pooled connection (`db.py:297-308`) is
+  recycled by other callers that expect autocommit mode; not restoring it silently breaks their writes.
+- **Migration #114 ordering:** the existing `#114` reclassify (`db.py:388-405`, bare `UPDATE` under
+  autocommit) runs at `init_db()` level outside this txn. On a fresh DB it no-ops (no listings); on an
+  upgrade it may run before/after the seed — benign (it only touches `description_source`, never
+  `lifecycle`/`matches`). The seed must run after the new tables exist (FK order, §3.2).
 
 **Contract-type mapping (O5 — RESOLVED, enumerated):**
 
@@ -331,22 +355,30 @@ Outer per-source/plugin loop is **unchanged** (`ingest.py` is DB-aware: `import 
 2nd role; it is replaced by upsert-listing-then-check-match-per-role:
 
 ```
+# upsert_listing(source, source_id, redirect_url, fields) -> listing_id:
+#   1. URL cross-source dedup (RETAINED from today): if listing_exists_by_url(redirect_url) → reuse that id
+#   2. INSERT ... ON CONFLICT (source, source_id) DO NOTHING RETURNING id
+#   3. if NO row returned (conflict path — listing already existed): SELECT id WHERE (source, source_id)
+#      ── the SELECT is MANDATORY (N1): ON CONFLICT DO NOTHING returns NO row on conflict, so the
+#         RETURNING id is null exactly in the pre-exists case the fan-out fix targets.
+# score_role(listing_id, role): INSERT INTO matches (...) ON CONFLICT (listing_id, role_id) DO NOTHING
+#      ── idempotent: a concurrent or re-run write cannot double-insert a (listing, role) Match.
+
 for each active SOURCE/PLUGIN:
-  if plugin.supports_role_query:                 # A-capable
-    for each active ROLE:
+  if plugin.supports_role_query:                       # A-capable
+    for each active ROLE (from run-start snapshot):
       fetch role-scoped query (role.search_what + filters)
       per listing:
-        hours → geo/residency → UPSERT listing (INSERT ... ON CONFLICT(source,source_id) DO NOTHING
-                                                 RETURNING id; else SELECT id)
-        if Match(listing_id, role_id) absent:
-            prefilter(role) → scrape JD (once, cached) → score(role) → write Match
-        # else: already scored for this role → skip
-  else:                                          # B-only global list
+        hours → geo/residency → id = upsert_listing(...)
+        if Match(id, role.id) absent:
+            prefilter(role) → scrape JD (once, cached) → score(role) → score_role(id, role)
+        # else: already scored for this (listing, role) → skip
+  else:                                                # B-only global list
     fetch global list
     per listing:
-      hours → geo/residency → UPSERT listing → scrape JD (once)
-      for each active ROLE whose prefilter(role) passes AND Match(listing_id, role_id) absent:
-          score(role) → write Match
+      hours → geo/residency → id = upsert_listing(...) → scrape JD (once)
+      for each active ROLE (snapshot) whose prefilter passes AND Match(id, role.id) absent:
+          score(role) → score_role(id, role)
 ```
 
 Key change: **dedup is per `(listing, role)` Match, not per listing row.** A role added to a pre-existing
@@ -390,13 +422,40 @@ across the role loop (note in `PLUGIN_DEVELOPMENT.md`).
 Response schema unchanged (`score, matched_skills, missing_skills, concerns, verdict`); written to a
 `Match` row.
 
+**Effective-skills resolution contract:** load the role's `applicable_skills` (JSONB `int[]`) + the
+candidate's `primary_skills`, filter in Python by id-membership (single-user scale; simplest). If done
+in SQL, bind `WHERE id = ANY(%s::int[])`. `applicable_skills` is a JSONB array → **no DB-level FK** to
+`skills.id`; a hard skill purge (rare) must application-level scrub `applicable_skills` arrays — a
+purge-time cleanup, never a hot-path concern.
+
 ### 4.6 Feed read authority during Cycle 1 (decision 2B) — was a v1 CONCERN
 
-`matches` is authoritative the moment it exists. **Cycle 1 includes a contained change to
-`get_feed()`/`get_snippet_feed()`** to read a roll-up `MAX(matches.score)` per listing (over active,
-non-archived roles), instead of `listings.score`. This is the "best-fit" scalar the Cycle-2 badge will
-also use — forward-compatible, not throwaway. Legacy `listings.score` is **not** read after this change
-(kept inert per §3.2). No dual-write, no split-brain window.
+`matches` is authoritative the moment it exists. Cycle 1 changes `get_feed()`/`get_snippet_feed()` to
+read from `matches` instead of `listings.score`. **It selects the best-fit Match ROW per listing, not a
+`MAX(score)` scalar (N2)** — a scalar max can't tell the card which role's `matched_skills`/`verdict`/
+`model_used` to render (`templates/_card.html` shows them), and isn't legal SQL beside non-aggregated
+columns. Use Postgres `DISTINCT ON`:
+
+```sql
+SELECT DISTINCT ON (m.listing_id) l.*, m.role_id, m.score, m.matched_skills, m.missing_skills,
+                                   m.concerns, m.verdict, m.model_used
+FROM listings l
+JOIN matches  m ON m.listing_id = l.id
+JOIN roles    r ON r.id = m.role_id AND r.active AND NOT r.archived   -- exclude paused/archived
+WHERE l.lifecycle = 'scored'
+  AND <get_feed: l.description_source='full' | get_snippet_feed: l.description_source='snippet'>
+  -- + existing feed filters (remote_only, search, job_type, sort, min_score/threshold)
+ORDER BY m.listing_id, m.score DESC;   -- best-fit role wins per listing
+```
+
+- **`get_snippet_feed()`** uses the same join with `description_source='snippet'` (N1 from the v2
+  review — its join shape is now explicit, not left to the implementer).
+- **All-archived / no-active-match listings** have no row from this join → **excluded from the feed**
+  (the `JOIN` + `r.active` predicate drops them; this is the intended behavior, stated explicitly).
+- The best-fit row is exactly what the Cycle-2 "best-fit" badge uses; the multi-role "also matches"
+  pills + Combined view layer on top in Cycle 2 — forward-compatible, not throwaway.
+- Legacy `listings.score`/`verdict`/… are **not** read after this change (inert per §3.2). No dual-write,
+  no split-brain window.
 
 ### 4.7 Snippets (store-then-score) + control surface
 
@@ -419,7 +478,13 @@ also use — forward-compatible, not throwaway. Legacy `listings.score` is **not
 - [ ] Remote-residency filter behaves (incompatible remote dropped; compatible passes outside radius).
 - [ ] `lifecycle` discovered→scored promotion; `lifecycle` × `description_source` coexist on one row correctly.
 - [ ] **Mid-run role edit/delete test:** archiving a role mid-run does not crash Match writes; staleness warning logged.
-- [ ] Feed reads `MAX(matches.score)` roll-up (decision 2B).
+- [ ] Feed selects the **best-fit Match row** (`DISTINCT ON`); the feed card renders that role's
+      `matched_skills`/`missing_skills`/`verdict`/`model_used`; listings whose only matches are
+      paused/archived roles are **excluded** (N2).
+- [ ] **Dedup-on-conflict test (N1):** `upsert_listing` returns a valid `id` on the *conflict* path
+      (pre-existing listing), not null; a re-run does not double-insert Matches (`ON CONFLICT DO NOTHING`).
+- [ ] **Hard-purge safety test (N3):** a purge is refused while a `python ingest.py` run holds the
+      advisory lock / has an `ingest_runs.status='running'` row (not just web-spawned ingest).
 - [ ] **Full CI gate green** (mirror CI, not a subset): `ruff check`, `pytest` (test DB), plus any
       `black --check` / `mypy` the workflow runs. State expected test count at plan time.
 
@@ -446,6 +511,10 @@ also use — forward-compatible, not throwaway. Legacy `listings.score` is **not
 | **D15** | Roles soft-delete only (`archived`); hard-purge is ingest-quiescent admin action (3A) | no mid-run FK crash; matches history preserved |
 | **D16** | PK = serial int; `slug` is a separate UNIQUE display key; FKs target the int | resolves the v1 PK/slug contradiction |
 | **D17** | B-mode worst case = K scoring calls for K matched roles; accepted + budget-logged (no hard cap) | single-user scale |
+| **D18** | Dedup: `RETURNING` is null on conflict → mandatory `SELECT id`; Match insert `ON CONFLICT DO NOTHING`; URL dedup retained | N1 (v2-review) |
+| **D19** | Cycle-1 feed selects best-fit Match **row** via `DISTINCT ON … ORDER BY score DESC` (not a scalar); all-archived listings excluded | N2 (v2-review) |
+| **D20** | Hard-purge gated by a cross-process DB signal (advisory lock / `ingest_runs.status`), not in-process `_ingest_running()` | N3 (v2-review) |
+| **D21** | Migration: `lifecycle` added nullable; backfill + `SET NOT NULL` + consistency assertion all INSIDE the txn; `autocommit` restored in `finally` | migration safety (v2-review) |
 
 ## 6. Open items
 

--- a/docs/superpowers/specs/2026-05-29-job-matcher-2.0-roles-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-29-job-matcher-2.0-roles-foundation-design.md
@@ -1,0 +1,386 @@
+# job-matcher 2.0 — Cycle 0 (Foundation) + Cycle 1 (Roles ingest/scoring) — design spec
+
+> **Status:** model LOCKED 2026-05-29. Awaiting user review of this spec before plan-writing.
+> **Tracking:** Epic glitchwerks/job-matcher#751 · milestone #12 · Cycle 0 #747 · Cycle 1 #748.
+> **Scope of this spec:** Cycles 0 and 1 only (the foundation + the ingest/scoring overhaul).
+> Cycle 2 (API + UI, #749) and Cycle 3 (Resumes, #750) get their own specs.
+
+---
+
+## 1. Background & intent
+
+job-matcher today is a single-profile job *scorer*: one `config/profile.json` (the candidate) plus
+one `config/config.json` search query drive an ingest pipeline that scores listings against a single
+profile and stores them in PostgreSQL. There is **no Role concept** and **no Resume concept** —
+"applied" is just a boolean column on `listings` (`db.py:359`).
+
+2.0 introduces two new core domain concepts:
+
+1. **Roles** — a single Profile targets **N roles** (e.g. Software Engineer, Data Engineer), each its
+   own search + scoring lens. A listing may match multiple roles (**many-to-many**).
+2. **Resumes** — a managed entity, tailorable to a job (Cycle 3 — out of scope here).
+
+This spec covers the **foundation** (the data model moved into PostgreSQL + migration) and the
+**ingest/scoring overhaul** that makes the pipeline multi-role aware.
+
+### Authority
+
+- **The model in this spec is authoritative** — it is the product of the brainstorming session
+  (2026-05-29) and supersedes the OpenDesign handoff docs where they differ.
+- OpenDesign `ui-layout.md` is authoritative for **UI/IA** (Cycle 2).
+- OpenDesign `data-model.md`, `api-surface.md`, `design-principles.md`, `roles-editor-rebuild.md`
+  are **bridging references**, captured 2026-05-29 at
+  `C:\Users\chris\AppData\Roaming\Open Design\namespaces\release-stable-win\data\projects\0115656f-3dfa-45ce-a2d7-e6857d2f2f6a\docs\`.
+
+> **Recommended follow-up (flagged, not done):** copy the four OpenDesign reference docs into the
+> repo (`docs/design/`) so this spec can cite them durably. External absolute paths are not durable
+> citations per the project's "Cite Sources" discipline. Pending user approval.
+
+---
+
+## 2. The three-category entity model (NORMATIVE)
+
+The model divides into three top-level categories the user navigates, plus the join + posting
+entities. `?` = optional/nullable. Types indicative; **verify exact types against the repo at build**.
+
+### 2.1 Profile (singleton) — "who the candidate is"
+
+```
+Profile {
+  // identity
+  name:             str
+  email:            str
+  country:          str
+  current_location: { label: str, lat?: num, lng?: num }   // home/base = distance ORIGIN
+  current_role:     str            // what they do today (≠ target roles)
+  residency:        {                                  // ← OUR model (gap in handoff docs)
+    authorized_regions: str[]      // e.g. ["US"] — where the candidate may legally work
+    needs_sponsorship:  bool
+  }
+  // identity facts
+  education:        Education[]
+  primary_skills:   Skill[]        // shared bucket {id,name,years} — see 2.2
+  // scoring baselines (apply to ALL roles; roles ADD to these — OUR model, decision #1/#2)
+  anti_preferences: str[]          // baseline list
+  scoring_notes:    str[]          // baseline list
+  // compensation anchor (NOT a floor) — seeds role.target_salary + drives feed delta
+  base_salary:      { amount: num, currency: str, period: "year"|"hour" }
+  // Tier-2 shared defaults a role may override
+  defaults:         { seniority: str, preferred_industries: str[] }
+}
+
+Education { degree_type: str, degree_field: str, school: str, graduation_year: int }
+```
+
+### 2.2 Skill — member of `Profile.primary_skills`
+
+```
+Skill {
+  id:    str     // STABLE id — roles reference skills by id (text key too fragile)
+  name:  str     // (was legacy `description`)
+  years: int     // (was legacy `years_active`)
+}
+// legacy `active` boolean is DROPPED. No per-role weighting anywhere — emphasis via scoring_notes.
+```
+
+### 2.3 Role (N per profile) — "what the candidate is aiming for"
+
+```
+Role {
+  id:     str
+  name:   str
+  color:  str            // identity color; UI shell recolors on switch (Cycle 2)
+  active: bool           // false = paused (stops ingesting; not deleted)
+
+  // Tier 1 — target-defined (no shared base)
+  search_what:   str               // the core query — this *is* the role
+  prefilter: { title_include: str[], title_exclude: str[] }
+  threshold:     num               // 0–10 min score to surface
+  scoring_notes: str[]             // per-role ADDITIONS (appended to Profile baseline)
+
+  // per-role attributes
+  anti_preferences:  str[]         // per-role ADDITIONS (appended to Profile baseline)
+  target_salary:     num           // seeded from profile.base_salary, then editable
+  applicable_skills: str[]         // BINARY refs into profile.primary_skills[].id
+  default_resume_id: str?          // Cycle 3 — linked default resume
+
+  // Tier 2 — shared default w/ override (SPARSE: present key = override; absent = inherit)
+  overrides: { seniority?: str, preferred_industries?: str[] }
+}
+```
+
+`location` / `radius` / `work_arrangement` / `job_types` are deliberately **absent** — they are
+global (Job Preferences), never per-role.
+
+### 2.4 Job Preferences (singleton, global) — "where & how the candidate will work"
+
+```
+JobPreferences {
+  locations:        Location[]                       // willing-to-work places
+  radius_km:        num                              // SINGLE global radius applied to every location
+  work_arrangement: ("onsite"|"hybrid"|"remote")[]   // multi-select HARD PULL FILTER
+  job_types:        ("contract"|"contract_to_hire"|"full_time"|"part_time"|"internship")[]  // HARD PULL FILTER
+  max_days_old:     int?                             // global freshness gate
+
+  // salary handling — user-selectable mode (OUR model, decision #3)
+  salary_mode:      "floor" | "display"
+  floor_amount:     num?            // required when salary_mode == "floor"
+}
+
+Location { label: str, lat?: num, lng?: num }   // NO per-location radius
+```
+
+- `work_arrangement` / `job_types` / `max_days_old` are **hard pull filters** — exclude postings at
+  ingestion, before LLM scoring.
+- **`salary_mode == "floor"`** → hard-filter out postings below `floor_amount` at ingestion.
+- **`salary_mode == "display"`** → no salary filter; the feed shows delta-vs-`base_salary`
+  (Cycle 2 UI): neutral text below base (`−10% vs base`), green above (`+20% vs base`).
+- **No extracted salary** is a **red flag, never an auto-drop** (Cycle 2 may offer an opt-in hide filter).
+
+### 2.5 Listing + Match (the posting and its per-role scores)
+
+```
+Listing {                          // the existing `listings` table, extended
+  ...all existing columns (title, company, location, salary_*, description, source, source_id, …)
+  state:             "snippet" | "scored"   // snippet = discovered, not yet LLM-scored (NEW)
+  applied_resume_id: str?                    // Cycle 3 link-only
+  // per-listing scoring columns (score, verdict, matched_skills, …) are SUPERSEDED by Match rows
+}
+
+Match {                            // NEW join — one row per (listing, role) scored pair
+  listing_id:     fk → listings.id
+  role_id:        fk → roles.id
+  score:          num              // 0–10 (tiers: hi 8+, mid 5–7, lo <5)
+  matched_skills: str[]            // serialized JSON (same pattern db.py uses today)
+  missing_skills: str[]
+  concerns:       str[]
+  verdict:        str
+  model_used:     str              // "provider/model"
+  tokens_input:   int
+  tokens_output:  int
+  overridden_via: str[]            // which Tier-2 overrides applied (Combined-view marker, Cycle 2)
+  PRIMARY KEY (listing_id, role_id)
+}
+```
+
+### 2.6 Entity-relationship summary
+
+```
+Profile (1) ──owns──> Skill (*)           Profile (1) ──owns──> Role (*)
+Role (*) ──applicable_skills──> Skill (*)  (binary id refs, many-to-many)
+Listing (1) ──< Match >── (1) Role         (many-to-many scoring; Match is the join)
+JobPreferences (1) ──hard-filters──> Listing ingestion
+Profile.base_salary ──derived %──> Listing.salary  (feed delta, Cycle 2)
+Resume / Application — DEFERRED to Cycle 3 (applied_resume_id is link-only)
+```
+
+---
+
+## 3. Cycle 0 — Foundation: schema + migration
+
+### 3.1 Current state (captured)
+
+- `listings` table: `db.py:332-366` (CREATE TABLE) — scoring lives in columns on this table today
+  (`score, matched_skills, missing_skills, concerns, verdict, model_used, tokens_*`, `db.py:348-358`).
+- Idempotent migration pattern: `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` loop, `db.py:368-382`.
+- `ingest_runs` table: `db.py:421-435`. Geocache: `db.py:410-416`.
+- Candidate fields today: `config/profile.example.json` (`primary_skills` with `description/years_active/active`,
+  `education`, `seniority`, `anti_preferences`, `preferred_industries`, `location{center,radius_km,…}`,
+  `scoring_notes`). Search/prefilter: `config/config.json` (`search.what/where/distance/salary_min/max_days_old`,
+  `scoring.threshold`, `prefilter.title_include/title_exclude/require_contract_*`).
+
+### 3.2 New tables (added to `db.init_db()`)
+
+All created with `CREATE TABLE IF NOT EXISTS`; column additions via the existing `ADD COLUMN IF NOT
+EXISTS` loop, so `init_db()` stays idempotent and safe to re-run (consistent with `db.py:368-382`).
+
+| Table | Shape | Notes |
+|---|---|---|
+| `profile` | singleton (enforce single row, e.g. `id=1`) | Profile (2.1); JSON columns for `education`, `anti_preferences`, `scoring_notes`, `defaults`, `residency`, `base_salary` following the existing JSON-in-TEXT pattern |
+| `skills` | rows `{id, name, years}` | stable `id` (e.g. slug or serial-backed text key) |
+| `job_preferences` | singleton | JobPreferences (2.4); `locations` as JSON; arrays as JSON |
+| `roles` | collection | Role (2.3); `prefilter`, `scoring_notes`, `anti_preferences`, `applicable_skills`, `overrides` as JSON columns |
+| `matches` | join, PK `(listing_id, role_id)` | Match (2.5); FKs to `listings.id` and `roles.id`; indexes on `role_id` and `listing_id` |
+
+`listings` additions: `state TEXT NOT NULL DEFAULT 'scored'`, `applied_resume_id TEXT NULL`.
+
+> **Decision — keep vs drop legacy scoring columns on `listings`.** Recommendation: **retain** the
+> legacy columns through Cycle 1 (do not drop), backfill `matches` from them during migration, and
+> have new writes target `matches`. Dropping is a separate cleanup once all reads move to `matches`
+> (Cycle 2). Rationale: avoids a destructive, hard-to-reverse migration mid-transition; the columns
+> are cheap to carry. Flag for reviewer.
+
+### 3.3 Migration (one-time, idempotent)
+
+1. **Seed Profile** from `config/profile.json`:
+   - `primary_skills[].description → name`, `years_active → years`, assign stable `id`; drop `active`.
+   - `education`, `anti_preferences` (→ baseline), `scoring_notes` (→ baseline) copied across.
+   - `seniority`, `preferred_industries` → `defaults`.
+   - `location.center` → `current_location.label`; `location.radius_km` → JobPreferences `radius_km`.
+   - `base_salary`, `residency`, `current_role` are **new** — seed empty/defaults; user fills via UI (Cycle 2).
+2. **Seed JobPreferences** from `config.json`: `search.distance`/`location.radius_km` → `radius_km`;
+   `max_days_old` → global; `prefilter.require_contract_*` → `job_types`/`work_arrangement` (best-effort
+   map, flag ambiguous); `search.salary_min` → `salary_mode="floor"`, `floor_amount=salary_min`
+   (preserves today's filtering behavior as the migration default).
+3. **Seed one Role** from `config.json` `search`: `search_what = search.what`, `prefilter` from
+   `prefilter.title_include/exclude`, `threshold = scoring.threshold`, `active = true`, a default color,
+   `applicable_skills = all skill ids` (so behavior is unchanged), empty per-role additions/overrides.
+4. **Backfill `matches`** from existing `listings` scoring columns against the single migrated Role:
+   one `Match` per already-scored listing (`seen=1`); set `listings.state='scored'`. Listings with
+   `seen=0` (score failed) → `state` stays `'scored'` with no match, or `'snippet'` — **decision: set
+   `'snippet'`** so the retry path (Cycle 1) re-scores them.
+
+Migration runs inside `db.init_db()` guarded by an existence check (skip if `profile` row present), so
+re-runs are no-ops — same defensive pattern as the JSearch reclassify migration (`db.py:388-405`).
+
+### 3.4 Cycle 0 acceptance criteria
+
+- [ ] `db.init_db()` creates all new tables; re-running is a no-op (idempotency test).
+- [ ] Migration populates Profile + JobPreferences + one Role from existing flat files.
+- [ ] Existing `listings` preserved; `matches` backfilled for `seen=1` rows; `seen=0` → `state='snippet'`.
+- [ ] Tests: schema creation, migration idempotency, JSON round-trip for the new JSON columns,
+      `conftest.py` test-DB guard respected (scoped DELETE by `source_id` prefix — no TRUNCATE).
+
+---
+
+## 4. Cycle 1 — Roles ingest/scoring overhaul
+
+### 4.1 The pipeline stays plugin-major
+
+The current pipeline iterates **per source/plugin** (pull → filter → scrape → score → insert), and
+`ingest.py` is already DB-aware (`import db` at `ingest.py:41`; `db.init_db()` `:1196`;
+`db.listing_exists()` `:1383`; geocache `:553-575`; `db.insert_listing()` `:639`). 2.0 keeps that
+outer loop **unchanged** — Roles are an *inner* fan-out, not a phase-major restructuring.
+
+```
+for each active SOURCE/PLUGIN:                       # OUTER LOOP — UNCHANGED
+  if plugin.supports_role_query:                     # A-capable: rich server-side filtering
+      for each active ROLE:
+          fetch role-scoped query (role.search_what + filters)
+          per listing:
+              hours filter → geo/residency filter → dedup (1 row per source/source_id)
+              → prefilter(role) → scrape JD (ONCE per listing) → score(role) → write Match
+  else:                                              # B-only: global list, no useful server filter
+      fetch global list
+      per listing:
+          hours filter → geo/residency filter → dedup → scrape JD (ONCE per listing)
+          for each active ROLE whose prefilter(role) passes:
+              score(role) → write Match
+```
+
+Invariants:
+- **Scoring is always per-Role**, written to `matches` (never to `listings` columns for new writes).
+- **Scrape happens once per listing**, shared across roles (cost) — even in B-mode where multiple
+  roles score the same listing.
+- The existing per-source short-circuit semantics are preserved (auth 401/403 drops a provider for
+  the run; transient failure skips the current listing) — see `credentials.score_listing_with_fallback`.
+
+### 4.2 Plugin capability flag
+
+Add `supports_role_query: bool` to the source-plugin contract (default `false` → B-mode, the safe
+fallback). A-capable plugins implement role-scoped fetch using `role.search_what` + the role's gates.
+Document in `docs/PLUGIN_DEVELOPMENT.md` and the `plugins/sources/_template/`.
+
+### 4.3 Per-role prefilter is the cost gate
+
+B-only sources scoring every listing against every active role multiplies LLM cost by role count.
+Mitigation (baked in): a listing is LLM-scored for a role **only if it passes that role's
+`prefilter.title_include/exclude`**. The prefilter is title-substring matching (cheap, no API call) —
+the same kind of gate that exists today, now evaluated per-role. A cost test asserts that a listing
+failing a role's prefilter incurs **zero** scoring calls for that role.
+
+### 4.4 Geo + residency filter
+
+- Distance origin = `Profile.current_location`; radius = `JobPreferences.radius_km`; applied to
+  `JobPreferences.locations[]` (a listing passes if within radius of **any** willing location).
+- A listing whose `work_arrangement` is **remote** **bypasses the distance filter** but is checked
+  against `Profile.residency` (`authorized_regions` / `needs_sponsorship`). Residency-incompatible
+  remote postings are filtered.
+- `geocode_fallback` behavior carries over from today (`pass` default).
+
+### 4.5 Effective scoring inputs per Role
+
+The LLM scoring prompt for a `(listing, role)` pair is assembled from:
+
+| Input | Source | Resolution |
+|---|---|---|
+| skills | `Profile.primary_skills` filtered by `role.applicable_skills` (binary) | `effective_skills = primary_skills.filter(s ∈ role.applicable_skills)` |
+| seniority | `role.overrides.seniority ?? profile.defaults.seniority` | sparse override |
+| preferred_industries | `role.overrides.preferred_industries ?? profile.defaults.preferred_industries` | sparse override |
+| anti_preferences | `profile.anti_preferences (baseline) + role.anti_preferences (additions)` | **concatenate** (OUR model) |
+| scoring_notes | `profile.scoring_notes (baseline) + role.scoring_notes (additions)` | **concatenate** (OUR model) |
+| target_salary | `role.target_salary` | per-role |
+| threshold | `role.threshold` | min score to surface |
+
+The scoring response schema is unchanged (`score, matched_skills, missing_skills, concerns, verdict`);
+results write to a `Match` row with `model_used` + token counts (as today, but per-role).
+
+### 4.6 Snippets (store-then-score)
+
+A discovered posting that has **not** been LLM-scored persists with `state='snippet'` (raw posting
+data, no `Match` rows). Scoring promotes it to `state='scored'` and writes its `Match` rows. This
+enables the Cycle 2 "awaiting scrape" feed state and an on-demand scrape/score action. In Cycle 1 the
+backend support is: write `state='snippet'` when a posting is stored pre-scoring, and a function to
+promote (scrape if needed → score → write matches → `state='scored'`).
+
+> **Decision — snippet creation policy.** Recommendation: a posting becomes a `snippet` when it
+> passes coarse filters + at least one role's prefilter but scoring is deferred/failed; the normal
+> path still scores inline and writes `state='scored'` directly. The "always store as snippet first,
+> score in a second pass" variant is a larger pipeline change — **defer** unless the reviewer wants it.
+> Flag for reviewer.
+
+### 4.7 CLI / control surface
+
+- **Role `active` toggle** — a run processes only `active=true` roles (read from DB at run start).
+- **`--role "<name>"`** — narrow a run to a single role (looked up by name/id in the DB). Works
+  because ingest is already DB-aware (`ingest.py:41`).
+- **`--rescore`** — rebuild `matches` across all active roles (extends today's `--rescore`). A
+  per-Role "re-score just this role's listings" action is also exposed (used by the Cycle 2 UI when a
+  single role is edited).
+
+### 4.8 Cycle 1 acceptance criteria
+
+- [ ] A-capable and B-only sources both produce correct per-role `Match` rows.
+- [ ] A listing matching two roles → two `Match` rows, one `listings` row.
+- [ ] Per-role prefilter gates LLM calls (cost test: prefilter-fail → 0 scoring calls for that role).
+- [ ] Remote-residency filter: a remote posting incompatible with `residency` is filtered; a
+      compatible one passes despite being outside the distance radius.
+- [ ] Snippet → scored promotion path covered by a test.
+- [ ] `--role` and `--rescore` (all-active + single-role) behave per 4.7.
+- [ ] **Full CI gate green** (mirror CI, not a subset): `ruff check`, `pytest` against the test DB,
+      plus any `black --check` / `mypy` the workflow runs. State expected test count at plan time.
+
+---
+
+## 5. Cross-cycle decisions log (2026-05-29)
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | `scoring_notes` = Profile baseline + per-Role additions | existing notes are general; superset is more flexible (our session, authoritative) |
+| D2 | `anti_preferences` = Profile baseline + per-Role additions | some universal, some role-specific |
+| D3 | Salary = `base_salary` anchor (Profile) + per-Role `target_salary` + user-selectable `salary_mode` (floor \| display) | richer than a flat floor; preserves filtering as an option |
+| D4 | `residency`/work-auth on Profile + remote-residency filter | gap in handoff docs; needed for correct remote filtering |
+| D5 | All config in PostgreSQL | enables UI CRUD, FK integrity for `matches`, role lifecycle; departs from legacy flat-file philosophy deliberately |
+| D6 | Ingest stays plugin-major; roles are inner fan-out | preserves proven structure + per-source short-circuit semantics |
+| D7 | Per-source `supports_role_query` flag; B-mode default | not all sources allow server-side filtering |
+| D8 | Many-to-many via `matches` join | preserves cross-role signal the LLM is paid to produce |
+| D9 | Scrape once per listing | cost |
+| D10 | Per-application resume = link only (`applied_resume_id`); Application entity deferred | lightest weight that satisfies the requirement |
+
+## 6. Open items for the reviewer
+
+- **O1** — Keep vs drop legacy `listings` scoring columns during transition (§3.2). Lean: keep through Cycle 1.
+- **O2** — Snippet creation policy: inline-score-default vs always-snippet-first (§4.6). Lean: inline default.
+- **O3** — `seen=0` listings → `state='snippet'` on migration (§3.3 step 4). Confirm.
+- **O4** — Copy OpenDesign reference docs into `docs/design/` for durable citations (§1). Needs user OK.
+- **O5** — Exact `job_types`/`work_arrangement` mapping from legacy `require_contract_*` (§3.3 step 2)
+  is best-effort; confirm the enum mapping at build.
+
+## 7. References
+
+- Current schema & migration pattern: `db.py:332-405` (listings + migrations), `db.py:421-435` (ingest_runs).
+- Ingest DB-awareness: `ingest.py:41` (`import db`), `:1196` (`init_db`), `:1383-1390` (dedup), `:639` (`insert_listing`).
+- Current candidate fields: `config/profile.example.json`; search/prefilter: `config/config.json` (CLAUDE.md § Config & profile).
+- OpenDesign handoff (captured 2026-05-29): `ui-layout.md` (UI authority), `data-model.md`, `api-surface.md`,
+  `design-principles.md`, `roles-editor-rebuild.md` (bridging references).
+- Tracking: Epic #751, milestone #12, Cycle 0 #747, Cycle 1 #748, Cycle 2 #749, Cycle 3 #750.

--- a/docs/superpowers/specs/2026-05-29-job-matcher-2.0-roles-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-29-job-matcher-2.0-roles-foundation-design.md
@@ -1,18 +1,35 @@
+---
+title: job-matcher 2.0 — Cycle 0 (Foundation) + Cycle 1 (Roles ingest/scoring)
+status: revised-v2 — re-review pending
+touches:
+  - db.py
+  - ingest.py
+  - web/feed.py
+  - web/**
+  - services/**
+  - plugins/sources/**
+  - templates/**
+  - conftest.py
+  - tests/**
+tracking: { epic: 751, milestone: 12, cycles: [747, 748] }
+---
+
 # job-matcher 2.0 — Cycle 0 (Foundation) + Cycle 1 (Roles ingest/scoring) — design spec
 
-> **Status:** model LOCKED 2026-05-29. Awaiting user review of this spec before plan-writing.
-> **Tracking:** Epic glitchwerks/job-matcher#751 · milestone #12 · Cycle 0 #747 · Cycle 1 #748.
-> **Scope of this spec:** Cycles 0 and 1 only (the foundation + the ingest/scoring overhaul).
-> Cycle 2 (API + UI, #749) and Cycle 3 (Resumes, #750) get their own specs.
+> **Status:** REVISED v2 — 2026-05-29. v1 was reviewed on PR glitchwerks/job-matcher#752 by
+> `project-reviewer` + `inquisitor` (aggressive pass); this revision resolves the 3 blockers + the PK
+> contradiction + the concerns they raised. **Not yet re-reviewed.** ("LOCKED" was premature in v1.)
+> **Tracking:** Epic #751 · milestone #12 · Cycle 0 #747 · Cycle 1 #748.
+> **Scope:** Cycles 0 and 1 only. Cycle 2 (API + UI, #749) and Cycle 3 (Resumes, #750) get their own specs.
 
 ---
 
 ## 1. Background & intent
 
-job-matcher today is a single-profile job *scorer*: one `config/profile.json` (the candidate) plus
-one `config/config.json` search query drive an ingest pipeline that scores listings against a single
-profile and stores them in PostgreSQL. There is **no Role concept** and **no Resume concept** —
-"applied" is just a boolean column on `listings` (`db.py:359`).
+job-matcher today is a single-profile job *scorer*: one `config/profile.json` + one `config/config.json`
+search query drive an ingest pipeline that scores listings against a single profile and stores them in
+PostgreSQL. There is **no Role concept** and **no Resume concept** — "applied" is a boolean column on
+`listings` (`db.py:359`).
 
 2.0 introduces two new core domain concepts:
 
@@ -20,55 +37,46 @@ profile and stores them in PostgreSQL. There is **no Role concept** and **no Res
    own search + scoring lens. A listing may match multiple roles (**many-to-many**).
 2. **Resumes** — a managed entity, tailorable to a job (Cycle 3 — out of scope here).
 
-This spec covers the **foundation** (the data model moved into PostgreSQL + migration) and the
-**ingest/scoring overhaul** that makes the pipeline multi-role aware.
+This spec covers the **foundation** (data model into PostgreSQL + migration) and the **ingest/scoring
+overhaul** that makes the pipeline multi-role aware.
 
 ### Authority
 
-- **The model in this spec is authoritative** — it is the product of the brainstorming session
-  (2026-05-29) and supersedes the OpenDesign handoff docs where they differ.
+- **The model in this spec is authoritative** (product of the 2026-05-29 brainstorming session); it
+  supersedes the OpenDesign handoff docs where they differ.
 - OpenDesign `ui-layout.md` is authoritative for **UI/IA** (Cycle 2).
-- OpenDesign `data-model.md`, `api-surface.md`, `design-principles.md`, `roles-editor-rebuild.md`
-  are **bridging references**, captured 2026-05-29 at
+- OpenDesign `data-model.md`, `api-surface.md`, `design-principles.md`, `roles-editor-rebuild.md` are
+  **bridging references**, captured 2026-05-29 at
   `C:\Users\chris\AppData\Roaming\Open Design\namespaces\release-stable-win\data\projects\0115656f-3dfa-45ce-a2d7-e6857d2f2f6a\docs\`.
 
-> **Recommended follow-up (flagged, not done):** copy the four OpenDesign reference docs into the
-> repo (`docs/design/`) so this spec can cite them durably. External absolute paths are not durable
-> citations per the project's "Cite Sources" discipline. Pending user approval.
+> **O4 (still open):** copy the four OpenDesign reference docs into the repo (`docs/design/`) so this
+> spec cites them durably. External absolute paths are not durable citations. Pending user OK.
 
 ---
 
 ## 2. The three-category entity model (NORMATIVE)
 
-The model divides into three top-level categories the user navigates, plus the join + posting
-entities. `?` = optional/nullable. Types indicative; **verify exact types against the repo at build**.
+`?` = optional/nullable. Types indicative; verify exact column types against the repo at build — EXCEPT
+where ADR-003/004/005/006 fix a type, which are normative.
 
 ### 2.1 Profile (singleton) — "who the candidate is"
 
 ```
 Profile {
-  // identity
+  id:               int        // serial PK; singleton enforced via CHECK (id = 1)
   name:             str
   email:            str
   country:          str
   current_location: { label: str, lat?: num, lng?: num }   // home/base = distance ORIGIN
-  current_role:     str            // what they do today (≠ target roles)
-  residency:        {                                  // ← OUR model (gap in handoff docs)
-    authorized_regions: str[]      // e.g. ["US"] — where the candidate may legally work
-    needs_sponsorship:  bool
-  }
-  // identity facts
+  current_role:     str
+  residency:        { authorized_regions: str[], needs_sponsorship: bool }   // OUR model (gap in handoff)
   education:        Education[]
-  primary_skills:   Skill[]        // shared bucket {id,name,years} — see 2.2
-  // scoring baselines (apply to ALL roles; roles ADD to these — OUR model, decision #1/#2)
-  anti_preferences: str[]          // baseline list
-  scoring_notes:    str[]          // baseline list
-  // compensation anchor (NOT a floor) — seeds role.target_salary + drives feed delta
-  base_salary:      { amount: num, currency: str, period: "year"|"hour" }
-  // Tier-2 shared defaults a role may override
-  defaults:         { seniority: str, preferred_industries: str[] }
+  primary_skills:   Skill[]        // shared bucket — see 2.2
+  anti_preferences: str[]          // baseline (roles ADD to this — D2)
+  scoring_notes:    str[]          // baseline (roles ADD to this — D1)
+  base_salary:      { amount: num, currency: str, period: "year"|"hour" }   // anchor, NOT a floor
+  defaults:         { seniority: str, preferred_industries: str[] }          // Tier-2 shared defaults
 }
-
 Education { degree_type: str, degree_field: str, school: str, graduation_year: int }
 ```
 
@@ -76,103 +84,142 @@ Education { degree_type: str, degree_field: str, school: str, graduation_year: i
 
 ```
 Skill {
-  id:    str     // STABLE id — roles reference skills by id (text key too fragile)
-  name:  str     // (was legacy `description`)
+  id:    int     // SERIAL PK — the cross-reference key (ADR-006). roles reference THIS.
+  slug:  str     // UNIQUE, human-stable display key (mutable name → slug regenerated is NOT done;
+                 //   slug is set once at create and stays; rename changes `name`, not `slug`)
+  name:  str     // display name (was legacy `description`); mutable
   years: int     // (was legacy `years_active`)
 }
-// legacy `active` boolean is DROPPED. No per-role weighting anywhere — emphasis via scoring_notes.
+// legacy `active` boolean DROPPED. No per-role weighting — emphasis via scoring_notes.
 ```
+
+**PK/FK resolution (was the v1 ADR-006-vs-§2 contradiction):** the FK target is the **serial int `id`**.
+`role.applicable_skills` stores **integer skill ids**, not slugs. The `slug` is a separate UNIQUE column
+for human-stable display/URLs only — never an FK target. Same pattern for Role (2.3).
 
 ### 2.3 Role (N per profile) — "what the candidate is aiming for"
 
 ```
 Role {
-  id:     str
-  name:   str
-  color:  str            // identity color; UI shell recolors on switch (Cycle 2)
-  active: bool           // false = paused (stops ingesting; not deleted)
+  id:       int          // SERIAL PK — FK target for matches.role_id (ADR-006)
+  slug:     str          // UNIQUE display key
+  name:     str
+  color:    str          // identity color (Cycle 2 shell)
+  active:   bool         // false = PAUSED (temporarily excluded from ingest; row & matches retained)
+  archived: bool         // true = soft-deleted (hidden from UI + ingest; row & matches retained) — see 2.7
 
-  // Tier 1 — target-defined (no shared base)
-  search_what:   str               // the core query — this *is* the role
-  prefilter: { title_include: str[], title_exclude: str[] }
-  threshold:     num               // 0–10 min score to surface
+  // Tier 1 — target-defined
+  search_what:   str
+  prefilter:     { title_include: str[], title_exclude: str[] }
+  threshold:     num
   scoring_notes: str[]             // per-role ADDITIONS (appended to Profile baseline)
 
   // per-role attributes
   anti_preferences:  str[]         // per-role ADDITIONS (appended to Profile baseline)
   target_salary:     num           // seeded from profile.base_salary, then editable
-  applicable_skills: str[]         // BINARY refs into profile.primary_skills[].id
-  default_resume_id: str?          // Cycle 3 — linked default resume
+  applicable_skills: int[]         // BINARY refs → skills.id (serial ints)
+  default_resume_id: int?          // Cycle 3
 
-  // Tier 2 — shared default w/ override (SPARSE: present key = override; absent = inherit)
+  // Tier 2 — sparse override (present key = override; absent = inherit)
   overrides: { seniority?: str, preferred_industries?: str[] }
+
+  updated_at: timestamptz          // bumped on any edit — drives mid-run staleness check (2.7)
 }
 ```
 
-`location` / `radius` / `work_arrangement` / `job_types` are deliberately **absent** — they are
-global (Job Preferences), never per-role.
+`location` / `radius` / `work_arrangement` / `job_types` are deliberately **absent** — global (2.4).
 
-### 2.4 Job Preferences (singleton, global) — "where & how the candidate will work"
+### 2.4 Job Preferences (singleton, global)
 
 ```
 JobPreferences {
-  locations:        Location[]                       // willing-to-work places
-  radius_km:        num                              // SINGLE global radius applied to every location
-  work_arrangement: ("onsite"|"hybrid"|"remote")[]   // multi-select HARD PULL FILTER
+  id:               int        // serial PK; singleton via CHECK (id = 1)
+  locations:        Location[]
+  radius_km:        num        // SINGLE global radius
+  work_arrangement: ("onsite"|"hybrid"|"remote")[]    // multi-select HARD PULL FILTER
   job_types:        ("contract"|"contract_to_hire"|"full_time"|"part_time"|"internship")[]  // HARD PULL FILTER
-  max_days_old:     int?                             // global freshness gate
-
-  // salary handling — user-selectable mode (OUR model, decision #3)
+  max_days_old:     int?
   salary_mode:      "floor" | "display"
-  floor_amount:     num?            // required when salary_mode == "floor"
+  floor_amount:     num?       // required when salary_mode == "floor"
 }
-
 Location { label: str, lat?: num, lng?: num }   // NO per-location radius
 ```
 
-- `work_arrangement` / `job_types` / `max_days_old` are **hard pull filters** — exclude postings at
-  ingestion, before LLM scoring.
-- **`salary_mode == "floor"`** → hard-filter out postings below `floor_amount` at ingestion.
-- **`salary_mode == "display"`** → no salary filter; the feed shows delta-vs-`base_salary`
-  (Cycle 2 UI): neutral text below base (`−10% vs base`), green above (`+20% vs base`).
-- **No extracted salary** is a **red flag, never an auto-drop** (Cycle 2 may offer an opt-in hide filter).
+- `work_arrangement` / `job_types` / `max_days_old` are **hard pull filters** (exclude at ingestion).
+- `salary_mode=="floor"` → drop postings below `floor_amount` at ingestion.
+- `salary_mode=="display"` → no salary filter; feed shows delta-vs-`base_salary` (Cycle 2): neutral below
+  base (`−10% vs base`), green above (`+20% vs base`).
+- **No extracted salary** = red flag, never auto-dropped (Cycle 2 may offer an opt-in hide filter).
 
 ### 2.5 Listing + Match (the posting and its per-role scores)
 
 ```
-Listing {                          // the existing `listings` table, extended
-  ...all existing columns (title, company, location, salary_*, description, source, source_id, …)
-  state:             "snippet" | "scored"   // snippet = discovered, not yet LLM-scored (NEW)
-  applied_resume_id: str?                    // Cycle 3 link-only
-  // per-listing scoring columns (score, verdict, matched_skills, …) are SUPERSEDED by Match rows
+Listing {                          // existing `listings` table, extended
+  ...all existing columns (title, company, location, salary_*, description, source, source_id,
+                           description_source, seen, …)
+  lifecycle:         "discovered" | "scored"   // NEW — see naming note below
+  applied_resume_id: int?                        // Cycle 3 link-only
+  // legacy scoring columns (score, verdict, matched_skills, …) are RETAINED but INERT in 2.0 —
+  //   read authority moves to `matches` in Cycle 1 (see §4.6); kept for backfill provenance/rollback.
 }
 
 Match {                            // NEW join — one row per (listing, role) scored pair
-  listing_id:     fk → listings.id
-  role_id:        fk → roles.id
-  score:          num              // 0–10 (tiers: hi 8+, mid 5–7, lo <5)
-  matched_skills: str[]            // serialized JSON (same pattern db.py uses today)
-  missing_skills: str[]
-  concerns:       str[]
+  listing_id:     int  fk → listings.id  ON DELETE CASCADE
+  role_id:        int  fk → roles.id     // roles are soft-deleted (2.7), so this never dangles
+  score:          num
+  matched_skills: jsonb            // ADR-005
+  missing_skills: jsonb
+  concerns:       jsonb
   verdict:        str
-  model_used:     str              // "provider/model"
+  model_used:     str
   tokens_input:   int
   tokens_output:  int
-  overridden_via: str[]            // which Tier-2 overrides applied (Combined-view marker, Cycle 2)
+  overridden_via: jsonb            // Tier-2 overrides applied (Combined-view marker, Cycle 2)
+  scored_at:      timestamptz
   PRIMARY KEY (listing_id, role_id)
 }
 ```
 
+**Naming note — `lifecycle`, NOT `state='snippet'` (was a v1 BLOCKER).** The repo already has
+`listings.description_source` (`'full'|'snippet'`, `db.py:363`) meaning *the description text came from a
+short API snippet vs a full scrape* — and that listing **has been scored**. The live `/snippets` route +
+`db.get_snippet_feed()` (`db.py:880-933`) surface `description_source='snippet' AND scored`. The new axis
+means something different — *not yet LLM-scored* — so it is a **separate column named `lifecycle`** with
+values `discovered`|`scored`. The two axes are orthogonal and both retained:
+
+| `description_source` (existing, unchanged) | `lifecycle` (new) | meaning |
+|---|---|---|
+| `full` / `snippet` | `discovered` | fetched, not yet scored (no Match rows) |
+| `full` | `scored` | scraped full JD, scored |
+| `snippet` | `scored` | scored from a short API description (today's `/snippets`) |
+
+The `/snippets` route + `get_snippet_feed()` keep filtering on `description_source='snippet'` (now also
+`lifecycle='scored'`). No vocabulary collision. The Cycle-2 "awaiting scrape/score" UI keys off
+`lifecycle='discovered'`.
+
 ### 2.6 Entity-relationship summary
 
 ```
-Profile (1) ──owns──> Skill (*)           Profile (1) ──owns──> Role (*)
-Role (*) ──applicable_skills──> Skill (*)  (binary id refs, many-to-many)
-Listing (1) ──< Match >── (1) Role         (many-to-many scoring; Match is the join)
+Profile (1) ──owns──> Skill (*)            Profile (1) ──owns──> Role (*)
+Role (*) ──applicable_skills (int refs)──> Skill (*)
+Listing (1) ──< Match >── (1) Role          (many-to-many; Match is the join)
 JobPreferences (1) ──hard-filters──> Listing ingestion
-Profile.base_salary ──derived %──> Listing.salary  (feed delta, Cycle 2)
+Profile.base_salary ──derived %──> feed delta (Cycle 2)
 Resume / Application — DEFERRED to Cycle 3 (applied_resume_id is link-only)
 ```
+
+### 2.7 Role lifecycle & ingest concurrency (was a v1 CONCERN)
+
+- **Soft-delete only (decision 3A).** UI "delete" sets `archived=true`; the row and `id` **never**
+  disappear, so `matches.role_id` never dangles and a mid-run Match write can't hit a missing-FK crash.
+  `active=false` = paused (temporary); `archived=true` = retired (permanent-ish, hidden). Archived roles
+  are excluded from ingest and the UI but their historical Matches stay valid.
+- **Hard purge** (truly delete a role + its Matches, `ON DELETE CASCADE`) is a separate explicit Admin
+  action, **gated on no ingest running** (checked via `ingest_control._ingest_running()`). Not exposed as
+  routine UI delete.
+- **Run-start snapshot + staleness.** Ingest snapshots active roles at run start (§4.7). If a role's
+  `updated_at` changes between snapshot and a Match write for that role, ingest logs a staleness warning
+  (the run used the snapshot config; the next run picks up edits). No mid-run config reload.
 
 ---
 
@@ -180,207 +227,241 @@ Resume / Application — DEFERRED to Cycle 3 (applied_resume_id is link-only)
 
 ### 3.1 Current state (captured)
 
-- `listings` table: `db.py:332-366` (CREATE TABLE) — scoring lives in columns on this table today
-  (`score, matched_skills, missing_skills, concerns, verdict, model_used, tokens_*`, `db.py:348-358`).
-- Idempotent migration pattern: `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` loop, `db.py:368-382`.
-- `ingest_runs` table: `db.py:421-435`. Geocache: `db.py:410-416`.
-- Candidate fields today: `config/profile.example.json` (`primary_skills` with `description/years_active/active`,
-  `education`, `seniority`, `anti_preferences`, `preferred_industries`, `location{center,radius_km,…}`,
-  `scoring_notes`). Search/prefilter: `config/config.json` (`search.what/where/distance/salary_min/max_days_old`,
-  `scoring.threshold`, `prefilter.title_include/title_exclude/require_contract_*`).
+- `listings`: `db.py:332-366`; scoring in columns (`db.py:348-358`); `description_source` at `:363`.
+- Idempotent migration pattern: `ADD COLUMN IF NOT EXISTS` loop, `db.py:368-382`; single-statement
+  guarded migration precedent (#114) `db.py:388-405`.
+- Connection pool is **autocommit=True** (`db.py:297-308`); `_Conn.commit()` exists for explicit txns.
+- `ingest_runs`: `db.py:421-435` (per-run `fetched/filtered/scored/failed_count`). Geocache `:410-416`.
+- Candidate fields: `config/profile.example.json`. Search/prefilter: `config/config.example.json`
+  (`prefilter.require_contract_time` ∈ {full_time, part_time}; `require_contract_type` ∈ {permanent, contract}
+  — verified `config.example.json:25-26`, matched in `ingest.py:394-407`).
 
 ### 3.2 New tables (added to `db.init_db()`)
 
-All created with `CREATE TABLE IF NOT EXISTS`; column additions via the existing `ADD COLUMN IF NOT
-EXISTS` loop, so `init_db()` stays idempotent and safe to re-run (consistent with `db.py:368-382`).
-
 | Table | Shape | Notes |
 |---|---|---|
-| `profile` | singleton (enforce single row, e.g. `id=1`) | Profile (2.1); JSON columns for `education`, `anti_preferences`, `scoring_notes`, `defaults`, `residency`, `base_salary` following the existing JSON-in-TEXT pattern |
-| `skills` | rows `{id, name, years}` | stable `id` (e.g. slug or serial-backed text key) |
-| `job_preferences` | singleton | JobPreferences (2.4); `locations` as JSON; arrays as JSON |
-| `roles` | collection | Role (2.3); `prefilter`, `scoring_notes`, `anti_preferences`, `applicable_skills`, `overrides` as JSON columns |
-| `matches` | join, PK `(listing_id, role_id)` | Match (2.5); FKs to `listings.id` and `roles.id`; indexes on `role_id` and `listing_id` |
+| `schema_version` | `(version int PK, applied_at timestamptz)` | NEW — migration sentinel; see §3.3 |
+| `profile` | singleton, `CHECK (id = 1)` | Profile (2.1); JSONB for `education/anti_preferences/scoring_notes/defaults/residency/base_salary` |
+| `skills` | `id SERIAL PK`, `slug TEXT UNIQUE`, `name`, `years` | FK target = `id` |
+| `job_preferences` | singleton, `CHECK (id = 1)` | JobPreferences (2.4); JSONB for arrays/locations |
+| `roles` | collection, `id SERIAL PK`, `slug UNIQUE` | Role (2.3); JSONB for `prefilter/scoring_notes/anti_preferences/applicable_skills/overrides`; `active/archived/updated_at` |
+| `matches` | join, PK `(listing_id, role_id)` | Match (2.5); FK `listing_id`→`listings.id` ON DELETE CASCADE, `role_id`→`roles.id`; indexes on `role_id`, `listing_id` |
 
-`listings` additions: `state TEXT NOT NULL DEFAULT 'scored'`, `applied_resume_id TEXT NULL`.
+`listings` additions: `lifecycle TEXT NOT NULL DEFAULT 'scored'`, `applied_resume_id INTEGER NULL`.
 
-> **Decision — keep vs drop legacy scoring columns on `listings`.** Recommendation: **retain** the
-> legacy columns through Cycle 1 (do not drop), backfill `matches` from them during migration, and
-> have new writes target `matches`. Dropping is a separate cleanup once all reads move to `matches`
-> (Cycle 2). Rationale: avoids a destructive, hard-to-reverse migration mid-transition; the columns
-> are cheap to carry. Flag for reviewer.
+**Table-creation order (was a v1 CONCERN):** `init_db()` must create parents before children —
+`skills`, `roles`, `job_preferences`, `profile` before `matches` (which FKs `roles` + `listings`).
+An integration test asserts `init_db()` succeeds against a **completely empty** DB.
 
-### 3.3 Migration (one-time, idempotent)
+**`db/` package + JSONB mappers (ADR-002/005):** the `db/` package split ships a `db/__init__.py` that
+re-exports all existing public symbols (callers' `import db` / `from db import …` keep working — no
+caller churn in Cycles 0–1). Each entity module owns its row mapper; the legacy TEXT-JSON
+`_deserialise_row` is **not** reused on JSONB tables (psycopg2 returns JSONB as Python objects already) —
+mixed-type joins (e.g. `listings` TEXT-JSON × `matches` JSONB) must use per-column-aware mapping.
 
-1. **Seed Profile** from `config/profile.json`:
-   - `primary_skills[].description → name`, `years_active → years`, assign stable `id`; drop `active`.
-   - `education`, `anti_preferences` (→ baseline), `scoring_notes` (→ baseline) copied across.
-   - `seniority`, `preferred_industries` → `defaults`.
-   - `location.center` → `current_location.label`; `location.radius_km` → JobPreferences `radius_km`.
-   - `base_salary`, `residency`, `current_role` are **new** — seed empty/defaults; user fills via UI (Cycle 2).
-2. **Seed JobPreferences** from `config.json`: `search.distance`/`location.radius_km` → `radius_km`;
-   `max_days_old` → global; `prefilter.require_contract_*` → `job_types`/`work_arrangement` (best-effort
-   map, flag ambiguous); `search.salary_min` → `salary_mode="floor"`, `floor_amount=salary_min`
-   (preserves today's filtering behavior as the migration default).
-3. **Seed one Role** from `config.json` `search`: `search_what = search.what`, `prefilter` from
-   `prefilter.title_include/exclude`, `threshold = scoring.threshold`, `active = true`, a default color,
-   `applicable_skills = all skill ids` (so behavior is unchanged), empty per-role additions/overrides.
-4. **Backfill `matches`** from existing `listings` scoring columns against the single migrated Role:
-   one `Match` per already-scored listing (`seen=1`); set `listings.state='scored'`. Listings with
-   `seen=0` (score failed) → `state` stays `'scored'` with no match, or `'snippet'` — **decision: set
-   `'snippet'`** so the retry path (Cycle 1) re-scores them.
+**`ingest_runs` multi-role accounting (was a v1 CONCERN):** add `matches_written INT`, `roles_processed
+INT`; `finish_ingest_run()` reports them. "scored" stays = listings transitioned to `lifecycle='scored'`.
 
-Migration runs inside `db.init_db()` guarded by an existence check (skip if `profile` row present), so
-re-runs are no-ops — same defensive pattern as the JSearch reclassify migration (`db.py:388-405`).
+**Legacy scoring columns (O1 — RESOLVED): retained but inert.** Keep `listings.score/verdict/...`
+through 2.0 for backfill provenance + rollback; **nothing reads them after Cycle 1** (feed reads
+`matches`, §4.6). Dropping them is a post-2.0 cleanup issue. Type conversions of existing `listings`
+columns (REAL/TEXT) are **out of scope** here (see ADR-003/004/005 scope note).
+
+### 3.3 Migration (one-time, ATOMIC, idempotent) — was a v1 BLOCKER
+
+Run inside `db.init_db()`, gated by `schema_version`. The seed runs in **one explicit transaction**
+(`raw.autocommit=False` for the block; `conn.commit()` once at the end — the seam at `db.py:297-308`):
+
+```
+if schema_version < 1:
+  BEGIN
+    1. Seed Profile from config/profile.json
+         (skills: description→name + assign slug + serial id; drop `active`;
+          education/anti_preferences→baseline/scoring_notes→baseline; seniority/preferred_industries→defaults;
+          location.center→current_location.label; base_salary/residency/current_role → empty defaults)
+    2. Seed JobPreferences from config.json (radius_km from search.distance/location.radius_km;
+         max_days_old; salary_min → salary_mode='floor', floor_amount=salary_min;
+         require_contract_* → job_types/work_arrangement per the table below)
+    3. Seed one Role from config.json search (search_what, prefilter, threshold, active=true,
+         archived=false, applicable_skills = ALL skill ids → behavior unchanged, empty additions/overrides)
+    4. Backfill matches: one Match per seen=1 listing against the seeded Role (copy score/verdict/
+         skills/concerns/model/tokens); set listing.lifecycle='scored'.
+         seen=0 listings (score failed) → lifecycle='discovered' (O3 RESOLVED) so Cycle-1 retry re-scores.
+    5. INSERT schema_version (1, now())
+  COMMIT   // all-or-nothing: an interrupted run rolls back; re-run repeats cleanly
+  ASSERT  (post-commit) COUNT(matches) == COUNT(listings WHERE seen=1)   // log + alert if mismatch
+```
+
+The guard is **`schema_version`**, not "profile row exists" — an interrupted run (no commit) leaves
+`schema_version` unset, so the next `init_db()` re-runs the whole seed cleanly. No half-migrated lock.
+
+**Contract-type mapping (O5 — RESOLVED, enumerated):**
+
+| legacy (`config.json`) | → new | note |
+|---|---|---|
+| `require_contract_time = "full_time"` | `job_types += [full_time]` | |
+| `require_contract_time = "part_time"` | `job_types += [part_time]` | |
+| `require_contract_type = "contract"` | `job_types += [contract]` | |
+| `require_contract_type = "permanent"` | (no member) | "permanent" = NOT-contract; represented by full/part-time presence, not a `job_types` entry |
+| field `null`/absent | no constraint on that axis | |
+| any unrecognized value | **log warning, drop (no filter)** | never silently over/under-filter |
+
+Because the legacy two-axis (time × type) model collapses into one `job_types` multiselect (lossy), a
+**first-run UI confirmation** (Cycle 2) prompts the user to verify migrated job-type prefs.
 
 ### 3.4 Cycle 0 acceptance criteria
 
-- [ ] `db.init_db()` creates all new tables; re-running is a no-op (idempotency test).
-- [ ] Migration populates Profile + JobPreferences + one Role from existing flat files.
-- [ ] Existing `listings` preserved; `matches` backfilled for `seen=1` rows; `seen=0` → `state='snippet'`.
-- [ ] Tests: schema creation, migration idempotency, JSON round-trip for the new JSON columns,
-      `conftest.py` test-DB guard respected (scoped DELETE by `source_id` prefix — no TRUNCATE).
+- [ ] `init_db()` creates all tables on a **completely empty** DB (FK order correct) and is a no-op on re-run.
+- [ ] Migration seeds Profile + JobPreferences + one Role from flat files; backfills `matches` for `seen=1`.
+- [ ] **Interrupted-migration test:** kill between step 1 and step 5 (no commit) → re-run completes the seed
+      (no half-migrated lock); post-commit assertion `COUNT(matches)==COUNT(seen=1)` holds.
+- [ ] `seen=0` → `lifecycle='discovered'`; `seen=1` → `lifecycle='scored'`.
+- [ ] Contract-type mapping table applied; unrecognized value logs + drops the filter.
+- [ ] JSONB round-trip; `conftest.py` test-DB guard respected (scoped DELETE by `source_id` prefix, no TRUNCATE).
 
 ---
 
 ## 4. Cycle 1 — Roles ingest/scoring overhaul
 
-### 4.1 The pipeline stays plugin-major
+### 4.1 Plugin-major loop with match-aware dedup (dedup fix was a v1 BLOCKER)
 
-The current pipeline iterates **per source/plugin** (pull → filter → scrape → score → insert), and
-`ingest.py` is already DB-aware (`import db` at `ingest.py:41`; `db.init_db()` `:1196`;
-`db.listing_exists()` `:1383`; geocache `:553-575`; `db.insert_listing()` `:639`). 2.0 keeps that
-outer loop **unchanged** — Roles are an *inner* fan-out, not a phase-major restructuring.
+Outer per-source/plugin loop is **unchanged** (`ingest.py` is DB-aware: `import db` `:41`; dedup `:1383`;
+`insert_listing` `:639`). Roles are an inner fan-out. **Dedup is now match-aware** — the old boolean
+`listing_exists()` skip (`ingest.py:1383-1394`) would short-circuit the whole listing and never score a
+2nd role; it is replaced by upsert-listing-then-check-match-per-role:
 
 ```
-for each active SOURCE/PLUGIN:                       # OUTER LOOP — UNCHANGED
-  if plugin.supports_role_query:                     # A-capable: rich server-side filtering
-      for each active ROLE:
-          fetch role-scoped query (role.search_what + filters)
-          per listing:
-              hours filter → geo/residency filter → dedup (1 row per source/source_id)
-              → prefilter(role) → scrape JD (ONCE per listing) → score(role) → write Match
-  else:                                              # B-only: global list, no useful server filter
-      fetch global list
+for each active SOURCE/PLUGIN:
+  if plugin.supports_role_query:                 # A-capable
+    for each active ROLE:
+      fetch role-scoped query (role.search_what + filters)
       per listing:
-          hours filter → geo/residency filter → dedup → scrape JD (ONCE per listing)
-          for each active ROLE whose prefilter(role) passes:
-              score(role) → write Match
+        hours → geo/residency → UPSERT listing (INSERT ... ON CONFLICT(source,source_id) DO NOTHING
+                                                 RETURNING id; else SELECT id)
+        if Match(listing_id, role_id) absent:
+            prefilter(role) → scrape JD (once, cached) → score(role) → write Match
+        # else: already scored for this role → skip
+  else:                                          # B-only global list
+    fetch global list
+    per listing:
+      hours → geo/residency → UPSERT listing → scrape JD (once)
+      for each active ROLE whose prefilter(role) passes AND Match(listing_id, role_id) absent:
+          score(role) → write Match
 ```
 
-Invariants:
-- **Scoring is always per-Role**, written to `matches` (never to `listings` columns for new writes).
-- **Scrape happens once per listing**, shared across roles (cost) — even in B-mode where multiple
-  roles score the same listing.
-- The existing per-source short-circuit semantics are preserved (auth 401/403 drops a provider for
-  the run; transient failure skips the current listing) — see `credentials.score_listing_with_fallback`.
+Key change: **dedup is per `(listing, role)` Match, not per listing row.** A role added to a pre-existing
+corpus now scores against existing listings (the bug v1 shipped). Scrape still happens once per listing.
+Per-source short-circuit semantics (401/403 drops a provider; transient skips the listing) preserved.
 
 ### 4.2 Plugin capability flag
 
-Add `supports_role_query: bool` to the source-plugin contract (default `false` → B-mode, the safe
-fallback). A-capable plugins implement role-scoped fetch using `role.search_what` + the role's gates.
-Document in `docs/PLUGIN_DEVELOPMENT.md` and the `plugins/sources/_template/`.
+Add `supports_role_query: bool` (default `False` → B-mode) as a class attribute on `JobSource`
+(`job_sources/base.py`), documented in `docs/PLUGIN_DEVELOPMENT.md` + `plugins/sources/_template/`.
 
-### 4.3 Per-role prefilter is the cost gate
+### 4.3 Per-role prefilter (cost gate) + B-mode cost ceiling (decision 4)
 
-B-only sources scoring every listing against every active role multiplies LLM cost by role count.
-Mitigation (baked in): a listing is LLM-scored for a role **only if it passes that role's
-`prefilter.title_include/exclude`**. The prefilter is title-substring matching (cheap, no API call) —
-the same kind of gate that exists today, now evaluated per-role. A cost test asserts that a listing
-failing a role's prefilter incurs **zero** scoring calls for that role.
+A listing is LLM-scored for a role only if it passes that role's `prefilter.title_include/exclude`
+(cheap title-substring gate; zero API cost for non-matches). **Accepted worst case:** a listing passing
+**K of N** roles' prefilters incurs **K scoring calls** (scrape is shared; scoring is not). At ~500
+listings/run × overlapping roles this is K× today's cost — **accepted for single-user scale (decision 4)**.
+Mitigation: ingest logs a **per-run scoring-call + estimated-cost budget line**; no hard cap in Cycle 1.
+A-capable sources also multiply *fetch* calls by role count → plugins must respect per-source rate limits
+across the role loop (note in `PLUGIN_DEVELOPMENT.md`).
 
 ### 4.4 Geo + residency filter
 
-- Distance origin = `Profile.current_location`; radius = `JobPreferences.radius_km`; applied to
-  `JobPreferences.locations[]` (a listing passes if within radius of **any** willing location).
-- A listing whose `work_arrangement` is **remote** **bypasses the distance filter** but is checked
-  against `Profile.residency` (`authorized_regions` / `needs_sponsorship`). Residency-incompatible
-  remote postings are filtered.
-- `geocode_fallback` behavior carries over from today (`pass` default).
+- Distance origin = `Profile.current_location`; radius = `JobPreferences.radius_km`; pass if within radius
+  of **any** willing `JobPreferences.locations[]`.
+- **Remote** postings bypass the distance filter but are checked against `Profile.residency`
+  (`authorized_regions`/`needs_sponsorship`); residency-incompatible remote postings filtered.
+- `geocode_fallback` carries over (`pass` default).
 
 ### 4.5 Effective scoring inputs per Role
 
-The LLM scoring prompt for a `(listing, role)` pair is assembled from:
+| Input | Resolution |
+|---|---|
+| skills | `primary_skills.filter(s.id ∈ role.applicable_skills)` |
+| seniority | `role.overrides.seniority ?? profile.defaults.seniority` |
+| preferred_industries | `role.overrides.preferred_industries ?? profile.defaults.preferred_industries` |
+| anti_preferences | `profile.anti_preferences ++ role.anti_preferences` (concatenate) |
+| scoring_notes | `profile.scoring_notes ++ role.scoring_notes` (concatenate) |
+| target_salary / threshold | per-role |
 
-| Input | Source | Resolution |
-|---|---|---|
-| skills | `Profile.primary_skills` filtered by `role.applicable_skills` (binary) | `effective_skills = primary_skills.filter(s ∈ role.applicable_skills)` |
-| seniority | `role.overrides.seniority ?? profile.defaults.seniority` | sparse override |
-| preferred_industries | `role.overrides.preferred_industries ?? profile.defaults.preferred_industries` | sparse override |
-| anti_preferences | `profile.anti_preferences (baseline) + role.anti_preferences (additions)` | **concatenate** (OUR model) |
-| scoring_notes | `profile.scoring_notes (baseline) + role.scoring_notes (additions)` | **concatenate** (OUR model) |
-| target_salary | `role.target_salary` | per-role |
-| threshold | `role.threshold` | min score to surface |
+Response schema unchanged (`score, matched_skills, missing_skills, concerns, verdict`); written to a
+`Match` row.
 
-The scoring response schema is unchanged (`score, matched_skills, missing_skills, concerns, verdict`);
-results write to a `Match` row with `model_used` + token counts (as today, but per-role).
+### 4.6 Feed read authority during Cycle 1 (decision 2B) — was a v1 CONCERN
 
-### 4.6 Snippets (store-then-score)
+`matches` is authoritative the moment it exists. **Cycle 1 includes a contained change to
+`get_feed()`/`get_snippet_feed()`** to read a roll-up `MAX(matches.score)` per listing (over active,
+non-archived roles), instead of `listings.score`. This is the "best-fit" scalar the Cycle-2 badge will
+also use — forward-compatible, not throwaway. Legacy `listings.score` is **not** read after this change
+(kept inert per §3.2). No dual-write, no split-brain window.
 
-A discovered posting that has **not** been LLM-scored persists with `state='snippet'` (raw posting
-data, no `Match` rows). Scoring promotes it to `state='scored'` and writes its `Match` rows. This
-enables the Cycle 2 "awaiting scrape" feed state and an on-demand scrape/score action. In Cycle 1 the
-backend support is: write `state='snippet'` when a posting is stored pre-scoring, and a function to
-promote (scrape if needed → score → write matches → `state='scored'`).
+### 4.7 Snippets (store-then-score) + control surface
 
-> **Decision — snippet creation policy.** Recommendation: a posting becomes a `snippet` when it
-> passes coarse filters + at least one role's prefilter but scoring is deferred/failed; the normal
-> path still scores inline and writes `state='scored'` directly. The "always store as snippet first,
-> score in a second pass" variant is a larger pipeline change — **defer** unless the reviewer wants it.
-> Flag for reviewer.
-
-### 4.7 CLI / control surface
-
-- **Role `active` toggle** — a run processes only `active=true` roles (read from DB at run start).
-- **`--role "<name>"`** — narrow a run to a single role (looked up by name/id in the DB). Works
-  because ingest is already DB-aware (`ingest.py:41`).
-- **`--rescore`** — rebuild `matches` across all active roles (extends today's `--rescore`). A
-  per-Role "re-score just this role's listings" action is also exposed (used by the Cycle 2 UI when a
-  single role is edited).
+- `lifecycle='discovered'` = stored, not yet scored (no Matches). Promotion: scrape-if-needed → score →
+  write Matches → `lifecycle='scored'`. **Inline-score remains the default** (O2 RESOLVED); a posting
+  becomes `discovered` only when scoring is deferred/failed. Failed-scoring carries a `score_error TEXT`
+  on the listing so the Cycle-2 UI can distinguish "awaiting score" from "score failed."
+- **Role active toggle** — run processes only `active=true AND archived=false` roles (snapshot at start, §2.7).
+- **`--role "<slug|name>"`** — narrow a run to one role (DB lookup).
+- **`--rescore`** — rebuild `matches` across active roles; per-Role "re-score just this role" action for
+  the Cycle-2 UI when a single role is edited.
 
 ### 4.8 Cycle 1 acceptance criteria
 
-- [ ] A-capable and B-only sources both produce correct per-role `Match` rows.
+- [ ] A-capable + B-only sources both produce correct per-role `Match` rows.
+- [ ] **Role-added-to-existing-corpus test:** score Role A, then add Role B and re-run → Role B gets
+      Matches for pre-existing listings (guards the dedup fix; do NOT test only the single-fresh-run path).
 - [ ] A listing matching two roles → two `Match` rows, one `listings` row.
-- [ ] Per-role prefilter gates LLM calls (cost test: prefilter-fail → 0 scoring calls for that role).
-- [ ] Remote-residency filter: a remote posting incompatible with `residency` is filtered; a
-      compatible one passes despite being outside the distance radius.
-- [ ] Snippet → scored promotion path covered by a test.
-- [ ] `--role` and `--rescore` (all-active + single-role) behave per 4.7.
-- [ ] **Full CI gate green** (mirror CI, not a subset): `ruff check`, `pytest` against the test DB,
-      plus any `black --check` / `mypy` the workflow runs. State expected test count at plan time.
+- [ ] Per-role prefilter gates LLM calls (prefilter-fail → 0 scoring calls); per-run cost budget logged.
+- [ ] Remote-residency filter behaves (incompatible remote dropped; compatible passes outside radius).
+- [ ] `lifecycle` discovered→scored promotion; `lifecycle` × `description_source` coexist on one row correctly.
+- [ ] **Mid-run role edit/delete test:** archiving a role mid-run does not crash Match writes; staleness warning logged.
+- [ ] Feed reads `MAX(matches.score)` roll-up (decision 2B).
+- [ ] **Full CI gate green** (mirror CI, not a subset): `ruff check`, `pytest` (test DB), plus any
+      `black --check` / `mypy` the workflow runs. State expected test count at plan time.
 
 ---
 
-## 5. Cross-cycle decisions log (2026-05-29)
+## 5. Cross-cycle decisions log
 
 | # | Decision | Rationale |
 |---|---|---|
-| D1 | `scoring_notes` = Profile baseline + per-Role additions | existing notes are general; superset is more flexible (our session, authoritative) |
+| D1 | `scoring_notes` = Profile baseline + per-Role additions | general baseline + role specifics |
 | D2 | `anti_preferences` = Profile baseline + per-Role additions | some universal, some role-specific |
-| D3 | Salary = `base_salary` anchor (Profile) + per-Role `target_salary` + user-selectable `salary_mode` (floor \| display) | richer than a flat floor; preserves filtering as an option |
-| D4 | `residency`/work-auth on Profile + remote-residency filter | gap in handoff docs; needed for correct remote filtering |
-| D5 | All config in PostgreSQL | enables UI CRUD, FK integrity for `matches`, role lifecycle; departs from legacy flat-file philosophy deliberately |
-| D6 | Ingest stays plugin-major; roles are inner fan-out | preserves proven structure + per-source short-circuit semantics |
-| D7 | Per-source `supports_role_query` flag; B-mode default | not all sources allow server-side filtering |
-| D8 | Many-to-many via `matches` join | preserves cross-role signal the LLM is paid to produce |
+| D3 | Salary = `base_salary` anchor + per-Role `target_salary` + `salary_mode` (floor\|display) | richer than a flat floor |
+| D4 | `residency` on Profile + remote-residency filter | gap in handoff docs |
+| D5 | All config in PostgreSQL | UI CRUD, FK integrity, role lifecycle |
+| D6 | Plugin-major loop; roles inner fan-out | preserves proven structure |
+| D7 | Per-source `supports_role_query`; B-mode default | not all sources allow server-side filtering |
+| D8 | Many-to-many via `matches` join | preserves cross-role signal |
 | D9 | Scrape once per listing | cost |
-| D10 | Per-application resume = link only (`applied_resume_id`); Application entity deferred | lightest weight that satisfies the requirement |
+| D10 | Per-application resume = link only; Application deferred | lightest weight |
+| **D11** | Lifecycle axis named `discovered`\|`scored`, separate from existing `description_source` | avoids the vocabulary collision (v1 blocker) |
+| **D12** | Dedup is match-aware (`(listing,role)`), not row-existence | makes the many-to-many fan-out actually work (v1 blocker) |
+| **D13** | Migration is one atomic transaction gated by `schema_version` | interrupted runs roll back, not half-lock (v1 blocker) |
+| **D14** | Cycle-1 feed reads `MAX(matches.score)` roll-up (2B) | `matches` authoritative immediately; no split-brain |
+| **D15** | Roles soft-delete only (`archived`); hard-purge is ingest-quiescent admin action (3A) | no mid-run FK crash; matches history preserved |
+| **D16** | PK = serial int; `slug` is a separate UNIQUE display key; FKs target the int | resolves the v1 PK/slug contradiction |
+| **D17** | B-mode worst case = K scoring calls for K matched roles; accepted + budget-logged (no hard cap) | single-user scale |
 
-## 6. Open items for the reviewer
+## 6. Open items
 
-- **O1** — Keep vs drop legacy `listings` scoring columns during transition (§3.2). Lean: keep through Cycle 1.
-- **O2** — Snippet creation policy: inline-score-default vs always-snippet-first (§4.6). Lean: inline default.
-- **O3** — `seen=0` listings → `state='snippet'` on migration (§3.3 step 4). Confirm.
-- **O4** — Copy OpenDesign reference docs into `docs/design/` for durable citations (§1). Needs user OK.
-- **O5** — Exact `job_types`/`work_arrangement` mapping from legacy `require_contract_*` (§3.3 step 2)
-  is best-effort; confirm the enum mapping at build.
+- **O4** — Copy OpenDesign reference docs into `docs/design/` for durable citations (§1). Pending user OK.
+  *(O1, O2, O3, O5 resolved in v2 — see §3.2/§4.7/§3.3.)*
 
 ## 7. References
 
-- Current schema & migration pattern: `db.py:332-405` (listings + migrations), `db.py:421-435` (ingest_runs).
-- Ingest DB-awareness: `ingest.py:41` (`import db`), `:1196` (`init_db`), `:1383-1390` (dedup), `:639` (`insert_listing`).
-- Current candidate fields: `config/profile.example.json`; search/prefilter: `config/config.json` (CLAUDE.md § Config & profile).
-- OpenDesign handoff (captured 2026-05-29): `ui-layout.md` (UI authority), `data-model.md`, `api-surface.md`,
-  `design-principles.md`, `roles-editor-rebuild.md` (bridging references).
-- Tracking: Epic #751, milestone #12, Cycle 0 #747, Cycle 1 #748, Cycle 2 #749, Cycle 3 #750.
+- Schema/migration: `db.py:332-405` (listings + migrations), `:297-308` (autocommit pool + commit seam),
+  `:363` (`description_source`), `:421-435` (`ingest_runs`), `:880-933` (`get_snippet_feed`).
+- Ingest: `ingest.py:41` (`import db`), `:1196` (`init_db`), `:1383-1394` (boolean dedup being replaced),
+  `:394-407` (contract-type prefilter), `:639` (`insert_listing`).
+- Contract-type values: `config/config.example.json:25-26`.
+- Feed render coupling (Cycle 2): `web/feed.py:77-94` / `:136-153`; history `glitchwerks/job-matcher-pr#223`/`#224`;
+  open `glitchwerks/job-matcher#580`/`#581`/`#582`.
+- Review of v1: PR #752 (`project-reviewer` + `inquisitor`, 2026-05-29).
+- OpenDesign handoff (captured 2026-05-29): `ui-layout.md` (UI authority) + `data-model.md`/`api-surface.md`/
+  `design-principles.md`/`roles-editor-rebuild.md` (bridging).
+- Tracking: epic #751, milestone #12, cycles #747–#750.


### PR DESCRIPTION
Planning artifacts for the **2.0** initiative (epic #751, milestone #12). Docs-only — no code changes.

## Adds two specs under `docs/superpowers/specs/`

1. **`2026-05-29-job-matcher-2.0-roles-foundation-design.md`** — Cycle 0+1 design:
   - Normative entity model: Profile / Skill / Role / Job Preferences / Listing + Match (many-to-many per-role scoring).
   - Cycle 0: new PostgreSQL tables + idempotent `db.init_db()` additions + one-time flat-file → DB migration.
   - Cycle 1: plugin-major / role-inner ingest+scoring overhaul — `supports_role_query` capability flag, per-role prefilter cost gate, geo+residency filter, snippets (`state`), `--role`/`--rescore`.
   - Decisions log (D1–D10), open items for review (O1–O5), cited `db.py`/`ingest.py` anchors.

2. **`2026-05-29-job-matcher-2.0-architecture-decisions.md`** — cross-cutting ADR (15 decisions):
   all-config-in-DB · no-ORM + `db/` package split · `NUMERIC` money · `TIMESTAMPTZ` · `JSONB` · serial-PK ID strategy · single-user (multi = v3) · HTMX kept but reversible via an API-first service layer · render discipline made **structural** (one chokepoint + CI contract tests) · explicit **PATCH** write-contract (absent/null/value) · secrets stay in file/secret-store · hand-rolled migrations for now · pydantic with the Cycle 2 API · local resume volume · SSE proxy note.

## Notes for reviewers
- The ADR captures the "is the core architecture still correct / what should change now" review from the brainstorming session. The render-coupling decisions (ADR-009) supersede open issues #580/#581/#582 on landing of Cycle 2.
- **This is planning only — no implementation authorized yet.** Each cycle gets its own plan + review gate.
- A `project-reviewer` (and optional `inquisitor`) architectural pass on these specs is the recommended next step before Cycle 0 plan-writing.

Refs #751 #747 #748. (No closing keywords — specs don't complete the cycles.)

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_