### PR TITLE
docs(#509): document SVG data-URI hex exception in style guide

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -16,6 +16,13 @@ The aesthetic is intentionally spare: one max-width column, no sidebar, no gradi
 
 All values live in the `:root` block of `static/style.css`. **Never hard-code hex values** — always reference a token.
 
+**Exception — inline SVG data URIs:** CSS custom properties cannot be referenced inside a `url("data:image/svg+xml,...")` payload, so hex color literals are permitted there. When you use one, add a comment naming the token it approximates and keep the two in sync by hand:
+
+```css
+/* chevron icon — approximates --border-strong (#525c72) at this opacity */
+background-image: url("data:image/svg+xml,%3Csvg ...fill='%23545c6b'.../%3E");
+```
+
 ### Backgrounds
 
 | Token | Value | Use |
@@ -779,7 +786,7 @@ Both states carry `margin-bottom: 16px` to maintain consistent spacing above `.c
 
 Follow these when writing new CSS or HTML:
 
-1. **Always use CSS custom properties.** Never hard-code a hex value. If no token fits, add one to `:root` and document it here.
+1. **Always use CSS custom properties.** Never hard-code a hex value. If no token fits, add one to `:root` and document it here. The one accepted exception is inline SVG data URIs — see the note in §2 Design Tokens.
 
 2. **Positive states use `--score-high-*`.** Anything that signals "good", "configured", "active", or "matching" uses the green tier triplet. This includes remote badges, validated keys, and matched skills.
 


### PR DESCRIPTION
Documents the accepted exception to the "never hard-code hex values" rule for inline SVG data URIs, which cannot reference `:root` CSS custom properties.

- Adds an authoritative exception note in §2 (Design Tokens) with an example showing the required "comment naming the mirrored token" convention.
- Cross-links from §7 rule 1 back to §2.
- The existing `select.edu-input` chevron note (line ~475) already relied on this exception; it now points at a documented rule.

Markdown-only. CI CRLF gate lints only `*.sh`/`*.bash`/`Dockerfile*`; no code gates affected.

Closes #509

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_