### PR TITLE
ci(#178): add djLint Jinja/HTML template linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
             exit 1
           fi
 
+      - name: Lint Jinja/HTML templates (djLint)
+        run: djlint templates/ --lint
+
   test:
     runs-on: ubuntu-latest
     services:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.djlint]
+profile = "jinja"
+indent = 2
+# H023: entity refs are intentional (icon glyphs, symbols — no icon-font dependency)
+# H030/H031: meta tags not required in partial/fragment templates
+# H021: inline styles are intentional in a handful of dynamic-colour components
+# H025: orphan tags are an HTMX pattern (partial responses)
+# J004/J018: url_for() refactor is out-of-scope for linting enforcement
+# T028: spaceless Jinja tags in class attributes are intentional for conditional classes
+ignore = "H023,H030,H031,H021,H025,J004,J018,T028"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 ruff
+djlint

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -13,7 +13,7 @@
   <script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/json-enc.js" integrity="sha384-nRnAvEUI7N/XvvowiMiq7oEI04gOXMCqD3Bidvedw+YNbj7zTQACPlRI3Jt3vYM4" crossorigin="anonymous"></script>
 </head>
 <body>
-{% include '_status_bar.html' %}
+{% include "_status_bar.html" %}
 <div class="page-wrap">
 
   {# ── Header ─────────────────────────────────────────────────── #}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
 </head>
 <body
   hx-on:ingestComplete="htmx.ajax('GET', '/feed/fragment', {target: '#feed-content', swap: 'outerHTML'})">
-{% include '_status_bar.html' %}
+{% include "_status_bar.html" %}
 {% if demo_mode %}
 <div class="demo-banner" role="status">&#x2697; Demo Mode &mdash; sample data only, no real API calls</div>
 {% endif %}
@@ -166,7 +166,7 @@
 
 </div>
 
-{% include '_ingest_drawer.html' %}
+{% include "_ingest_drawer.html" %}
 <script src="{{ url_for('static', filename='ingest-drawer.js') }}"></script>
 </body>
 </html>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -245,7 +245,7 @@
   </style>
 </head>
 <body>
-{% include '_status_bar.html' %}
+{% include "_status_bar.html" %}
 {% if demo_mode %}
 <div class="demo-banner" role="status">&#x2697; Demo Mode &mdash; sample data only, no real API calls</div>
 {% endif %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -252,7 +252,7 @@
   </style>
 </head>
 <body>
-{% include '_status_bar.html' %}
+{% include "_status_bar.html" %}
 {% if demo_mode %}
 <div class="demo-banner" role="status">&#x2697; Demo Mode &mdash; sample data only, no real API calls</div>
 {% endif %}
@@ -604,7 +604,6 @@
       <button type="submit" class="btn btn-save">Save</button>
     </form>
   </div>
-
 
 </div>
 

--- a/templates/snippets.html
+++ b/templates/snippets.html
@@ -11,7 +11,7 @@
   <script src="https://unpkg.com/htmx.org@1.9.10/dist/htmx.min.js" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
 </head>
 <body>
-{% include '_status_bar.html' %}
+{% include "_status_bar.html" %}
 <div class="page-wrap">
 
   {# ── Header ─────────────────────────────────────────────────── #}

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-{% include '_status_bar.html' %}
+{% include "_status_bar.html" %}
 {% if demo_mode %}
 <div class="demo-banner" role="status">&#x2697; Demo Mode &mdash; sample data only, no real API calls</div>
 {% endif %}
@@ -120,7 +120,6 @@
       {{ stats.unknown_models | join(', ') }}.
     {% endif %}
   </p>
-
 
 </div>
 </body>


### PR DESCRIPTION
Adds djLint template linting to the existing `lint` job in `ci.yml`.

- New `[tool.djlint]` config in `pyproject.toml` (`profile = "jinja"`, `indent = 2`) with a documented `ignore` list (each rule justified: H023 intentional glyph entities, H030/H031 partials, H021 dynamic inline styles, H025 HTMX fragments, J004/J018 `url_for` refactor out of scope, T028 spaceless conditional classes).
- `djlint` added to `requirements-dev.txt`.
- Fixed 9 real violations across 6 templates: 7× T002 (include-quote style) + 2× H014 (extra blank lines).

**Verification:** `ruff check .` PASS; `djlint templates/ --lint` PASS (0 errors, 17 files); non-DB pytest subset PASS (49 passed, 1 skipped). Full pytest requires a DB and runs in CI against a fresh postgres container.

Closes #178

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_