### PR TITLE
fix(#757): harden settings validation against flaky 500 (test isolation + safety net)

### DIFF
--- a/services/provider_schemas.py
+++ b/services/provider_schemas.py
@@ -278,6 +278,12 @@ def _get_search_validation_issues(
     ``/api/ingest/preflight`` endpoint so the same validation logic is never
     duplicated.
 
+    Any unexpected exception from the underlying validation (e.g. a
+    :class:`filelock.Timeout` when :func:`credentials.migrate_from_legacy`
+    tries to acquire a write lock on the providers path) is caught here and
+    logged as a warning.  This prevents a transient I/O error from turning
+    into a ``GET /settings`` HTTP 500.
+
     Args:
         providers_path: Override path to ``providers.json``.  Defaults to
             :data:`services.profile_store._PROVIDERS_PATH`.
@@ -293,7 +299,16 @@ def _get_search_validation_issues(
     if config_path is None:
         config_path = _CONFIG_PATH
     mts = (_mtime(providers_path), _mtime(config_path))
-    return _cached_validation(mts, providers_path, config_path)
+    try:
+        return _cached_validation(mts, providers_path, config_path)
+    except Exception as exc:
+        _logger.warning(
+            "Search-config validation failed unexpectedly; "
+            "returning empty issue list so /settings can still render. "
+            "Error: %s",
+            exc,
+        )
+        return []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_clear_db.py
+++ b/tests/test_clear_db.py
@@ -376,12 +376,34 @@ def tmp_keys_path(tmp_path, monkeypatch):
     return path
 
 
+@pytest.fixture()
+def tmp_config_path(tmp_path, monkeypatch):
+    """Isolate config.json from the real config directory.
+
+    Prevents _get_search_validation_issues from reading or being affected by
+    any real config/config.json that may exist on a developer machine, and
+    ensures the lru_cache keyed on (providers_mtime, config_mtime) does not
+    share entries with other tests that use different path pairs.
+
+    Without this fixture the settings route uses the real _CONFIG_PATH
+    (which may exist on some machines) while other fixtures redirect
+    _PROVIDERS_PATH to a temp file — creating a mixed-path cache key that
+    can interact with other test sessions or a stale lru_cache entry.
+    """
+    import services.profile_store as _profile_store_module
+    import web.settings as _settings_module
+    path = str(tmp_path / "config.json")
+    monkeypatch.setattr(_profile_store_module, "_CONFIG_PATH", path)
+    monkeypatch.setattr(_settings_module, "_CONFIG_PATH", path)
+    return path
+
+
 class TestSettingsPageRenders:
     def teardown_method(self):
         _cleanup(_PREFIX)
 
     def test_settings_page_renders_ok(
-        self, client, tmp_providers_path, tmp_keys_path
+        self, client, tmp_providers_path, tmp_keys_path, tmp_config_path
     ):
         """GET /settings page renders without error (listing_count is no longer shown here)."""
         _insert("cdb-st-001")
@@ -391,7 +413,7 @@ class TestSettingsPageRenders:
         assert resp.data
 
     def test_settings_page_renders_ok_when_empty(
-        self, client, tmp_providers_path, tmp_keys_path
+        self, client, tmp_providers_path, tmp_keys_path, tmp_config_path
     ):
         """GET /settings renders without error even when no listings inserted."""
         resp = client.get("/settings")

--- a/tests/test_validation_cache.py
+++ b/tests/test_validation_cache.py
@@ -171,3 +171,80 @@ class TestValidationIssuesCache:
         )
         assert result_first == [first_issue]
         assert result_second == [second_issue]
+
+
+class TestGetSearchValidationIssuesSafetyNet:
+    """_get_search_validation_issues() must not propagate any exception.
+
+    The function is called from GET /settings and GET /api/ingest/preflight.
+    Any uncaught exception from _cached_validation would produce an HTTP 500.
+    This class verifies the outer wrapper catches unexpected errors gracefully.
+
+    Regression test for issue #757: test_settings_page_renders failed with
+    HTTP 500 when _cached_validation was called without a tmp_config_path
+    fixture isolating _CONFIG_PATH, leaving an opportunity for an unexpected
+    exception (e.g. filelock.Timeout) to escape to the Flask route.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        _schemas_mod._cached_validation.cache_clear()
+        yield
+        _schemas_mod._cached_validation.cache_clear()
+
+    def test_returns_empty_list_when_cached_validation_raises(self, tmp_path):
+        """Any exception from _cached_validation is caught; empty list returned."""
+        providers_path = str(tmp_path / "providers.json")
+        config_path = str(tmp_path / "config.json")
+        _write_providers(providers_path)
+        _write_config(config_path)
+
+        def _exploding_validate(*_args, **_kwargs):
+            raise RuntimeError("simulated filelock.Timeout or other I/O error")
+
+        with patch.object(
+            _schemas_mod, "_cached_validation", side_effect=_exploding_validate
+        ):
+            result = _get_search_validation_issues(
+                providers_path=providers_path,
+                config_path=config_path,
+            )
+
+        assert result == [], (
+            "_get_search_validation_issues must return [] when _cached_validation raises, "
+            "never propagate the exception to the Flask route"
+        )
+
+    def test_settings_page_renders_when_config_path_not_isolated(self, tmp_path, monkeypatch):
+        """GET /settings returns 200 even when _CONFIG_PATH is not overridden in a test.
+
+        This is the regression scenario from issue #757: TestSettingsPageRenders
+        used tmp_providers_path and tmp_keys_path but lacked tmp_config_path.
+        The real _CONFIG_PATH (which may or may not exist) was used alongside
+        the temp providers path, creating a mixed-path cache key.  Any
+        exception from that combination must not bubble up as a 500.
+        """
+        import web.settings as _settings_module
+        import services.profile_store as _profile_store_module
+        from app import app as flask_app
+
+        flask_app.config["TESTING"] = True
+        providers_path = str(tmp_path / "providers.json")
+        keys_path = str(tmp_path / "keys.json")
+        # Intentionally do NOT create a config.json at config_path.
+        missing_config = str(tmp_path / "config.json")
+
+        monkeypatch.setattr(_profile_store_module, "_PROVIDERS_PATH", providers_path)
+        monkeypatch.setattr(_profile_store_module, "_KEYS_PATH", keys_path)
+        monkeypatch.setattr(_profile_store_module, "_CONFIG_PATH", missing_config)
+        monkeypatch.setattr(_settings_module, "_PROVIDERS_PATH", providers_path)
+        monkeypatch.setattr(_settings_module, "_KEYS_PATH", keys_path)
+        monkeypatch.setattr(_settings_module, "_CONFIG_PATH", missing_config)
+
+        with flask_app.test_client() as c:
+            resp = c.get("/settings")
+
+        assert resp.status_code == 200, (
+            "GET /settings must return 200 even when config.json is absent and "
+            "the config path is not isolated by tmp_config_path"
+        )


### PR DESCRIPTION
Fixes a latent flaky HTTP 500 on `GET /settings` and `GET /api/ingest/preflight`.

## Root cause
`TestSettingsPageRenders` (`tests/test_clear_db.py`) patched `_PROVIDERS_PATH`/`_KEYS_PATH` but **not** `_CONFIG_PATH`. When a real `config/config.json` / `keys.json` exists in the default dir, the settings render path called `load_providers()` with default fallback paths → `migrate_from_legacy()` → `atomic_config_write()` → a `filelock` exception. `_cached_validation` only caught `CredentialError`/`SystemExit`, so it propagated as a 500. Flakiness depended on whether those default files existed in a given environment/run.

## Fix (defense-in-depth)
1. **Test isolation** (`tests/test_clear_db.py`): add the missing `tmp_config_path` fixture to both `TestSettingsPageRenders` tests, matching every other settings test class.
2. **Safety net** (`services/provider_schemas.py`): wrap the `_cached_validation(...)` call in `_get_search_validation_issues()` (the single entry point for `/settings` and `/api/ingest/preflight`) in `try/except Exception` → log a warning and return `[]` rather than 500.

## Regression tests (`tests/test_validation_cache.py`)
- `test_returns_empty_list_when_cached_validation_raises`
- `test_settings_page_renders_when_config_path_not_isolated`

## Verification
`ruff check .` clean; full suite **2135 passed, 1 skipped** (2 new tests vs prior baseline).

Note: `main` CI was already green — this fixes a *latent* flake, not an active red build (see issue correction).

Fixes #757

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_