### PR TITLE
feat(#602): ingest observability — immediate log flush, pool-wait timeout, heartbeat

### DIFF
--- a/db.py
+++ b/db.py
@@ -25,6 +25,7 @@ immediately rather than at the first database call.
 import json
 import logging
 import os
+import queue
 import threading
 from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
@@ -217,6 +218,21 @@ def _lookup_pricing(model_used: str | None) -> tuple[float, float] | None:
 # Connection pool — initialised once at module import.
 # ---------------------------------------------------------------------------
 
+# How long (in seconds) get_connection() waits for a connection from an
+# exhausted pool before raising PoolWaitTimeout.  Callers may override this
+# per-call via the pool_wait_timeout parameter.
+POOL_WAIT_TIMEOUT_SECONDS: float = 30.0
+
+
+class PoolWaitTimeout(Exception):
+    """Raised by get_connection() when the pool is exhausted and the
+    configured wait timeout elapses before a connection becomes available.
+
+    Allows callers to catch a bounded failure instead of hanging indefinitely
+    when all connections in the ThreadedConnectionPool are in use.
+    """
+
+
 _pool: psycopg2.pool.ThreadedConnectionPool | None = None
 _pool_lock = threading.Lock()
 
@@ -291,7 +307,9 @@ class _Conn:
 # Connection factory
 # ---------------------------------------------------------------------------
 
-def get_connection() -> _Conn:
+def get_connection(
+    pool_wait_timeout: float = POOL_WAIT_TIMEOUT_SECONDS,
+) -> _Conn:
     """Check out a connection from the pool and return it wrapped in ``_Conn``.
 
     The connection has ``autocommit=True`` so every statement auto-commits in
@@ -302,9 +320,52 @@ def get_connection() -> _Conn:
 
     The caller is responsible for closing the connection (which returns it to
     the pool), either explicitly or via the ``_Conn`` context manager.
+
+    Args:
+        pool_wait_timeout: Seconds to wait for a connection before raising
+            :class:`PoolWaitTimeout`.  Defaults to
+            :data:`POOL_WAIT_TIMEOUT_SECONDS` (30 s).  Pass a smaller value
+            in tests to keep them snappy.
+
+    Returns:
+        A :class:`_Conn` wrapping the checked-out psycopg2 connection.
+
+    Raises:
+        PoolWaitTimeout: If the pool is exhausted and *pool_wait_timeout*
+            elapses before a connection becomes available.
     """
     pool = _get_pool()
-    raw = pool.getconn()
+
+    # psycopg2's ThreadedConnectionPool.getconn() blocks indefinitely when the
+    # pool is exhausted.  Run it on a daemon thread and use a result queue with
+    # a bounded get() timeout to avoid hanging forever.  The worker thread is a
+    # daemon so it does not prevent process exit if it is still blocked when the
+    # timeout fires (e.g. because every pool slot is genuinely in use).
+    _result_q: queue.Queue = queue.Queue(maxsize=1)
+
+    def _worker() -> None:
+        try:
+            conn = pool.getconn()
+            _result_q.put(("ok", conn))
+        except Exception as _exc:  # noqa: BLE001
+            _result_q.put(("err", _exc))
+
+    _t = threading.Thread(target=_worker, daemon=True)
+    _t.start()
+
+    try:
+        outcome, value = _result_q.get(timeout=pool_wait_timeout)
+    except queue.Empty:
+        raise PoolWaitTimeout(
+            f"Connection pool exhausted: no connection available within "
+            f"{pool_wait_timeout:.1f}s. Increase the pool size (maxconn) "
+            "or reduce concurrent workers."
+        ) from None
+
+    if outcome == "err":
+        raise value  # type: ignore[misc]
+
+    raw = value
     raw.autocommit = True
     return _Conn(raw, pool)
 

--- a/ingest.py
+++ b/ingest.py
@@ -26,6 +26,7 @@ import math
 import os
 import re
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -61,6 +62,31 @@ _DEFAULT_PROVIDERS_PATH = os.path.join(_CONFIG_DIR, "providers.json")
 # ---------------------------------------------------------------------------
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger("ingest")
+
+
+class ImmediateFlushHandler(logging.FileHandler):
+    """A FileHandler that calls flush() after every emitted record.
+
+    The default ``logging.FileHandler`` buffers writes to the underlying
+    stream and only flushes when the buffer fills or the handler is closed.
+    On a long-running ingest pipeline this causes the log file to appear
+    empty — or stale — for minutes at a time, making it impossible to tell
+    whether the process is still making progress.
+
+    ``ImmediateFlushHandler`` overrides :meth:`emit` to flush immediately
+    after each record so that every log line is on disk as soon as it is
+    written.  The performance overhead is negligible for the ingest use case
+    (tens of records per minute at most).
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Emit *record* and flush the underlying stream immediately.
+
+        Args:
+            record: The log record to write.
+        """
+        super().emit(record)
+        self.flush()
 
 # Set to True by --verbose / -v CLI flag. Used at scoring callsites to emit
 # the full breakdown (verdict, matched/missing skills, concerns) at INFO level.
@@ -120,7 +146,7 @@ def _configure_file_logging() -> None:
     _current_log_file = log_file
 
     try:
-        handler = logging.FileHandler(log_file, encoding="utf-8")
+        handler = ImmediateFlushHandler(log_file, encoding="utf-8")
         handler.setFormatter(
             logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
         )
@@ -1135,6 +1161,84 @@ def _safe_pages(client):
 
 
 # ---------------------------------------------------------------------------
+# Heartbeat
+# ---------------------------------------------------------------------------
+
+# How often (in seconds) the heartbeat thread emits a progress log line.
+# Can be overridden at construction time; the module-level constant is the
+# default used by run().
+_HEARTBEAT_INTERVAL_SECONDS = 30
+
+
+class _HeartbeatThread(threading.Thread):
+    """Daemon thread that logs a progress line at a configurable interval.
+
+    Useful for confirming that a long ingest run is still making progress
+    rather than silently hanging.  The heartbeat message includes the
+    number of listings scored so far, the total fetched, and the current
+    pipeline stage.
+
+    The thread is a **daemon** so it is automatically killed when the main
+    process exits, regardless of whether :attr:`stop_event` was set.
+
+    Usage::
+
+        stop = threading.Event()
+        hb = _HeartbeatThread(
+            stop_event=stop,
+            interval_seconds=30,
+            get_counts=lambda: (scored, fetched, stage),
+        )
+        hb.start()
+        # ... run the pipeline ...
+        stop.set()
+        hb.join()
+
+    Attributes:
+        stop_event:       A :class:`threading.Event` that signals the
+                          thread to exit cleanly.
+        interval_seconds: Seconds between heartbeat log lines.
+        get_counts:       Zero-argument callable that returns a 3-tuple
+                          ``(scored: int, fetched: int, stage: str)``.
+    """
+
+    def __init__(
+        self,
+        stop_event: threading.Event,
+        interval_seconds: float,
+        get_counts,  # () -> tuple[int, int, str]
+    ) -> None:
+        """Initialise the heartbeat thread.
+
+        Args:
+            stop_event:       Event that signals the thread to stop.
+            interval_seconds: Seconds between heartbeat emissions.
+            get_counts:       Callable returning ``(scored, fetched, stage)``.
+        """
+        super().__init__(name="ingest-heartbeat", daemon=True)
+        self._stop_event = stop_event
+        self._interval = interval_seconds
+        self._get_counts = get_counts
+
+    def run(self) -> None:
+        """Emit heartbeat lines until *stop_event* is set."""
+        _hb_log = logging.getLogger("ingest")
+        while not self._stop_event.wait(timeout=self._interval):
+            try:
+                scored, fetched, stage = self._get_counts()
+                _hb_log.info(
+                    "Heartbeat — still working: %d/%d listings processed, "
+                    "current stage=%s",
+                    scored,
+                    fetched,
+                    stage,
+                )
+            except Exception:  # noqa: BLE001
+                # Never let an error in get_counts() kill the heartbeat thread.
+                pass
+
+
+# ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
 
@@ -1333,6 +1437,24 @@ def run(
             from datetime import timedelta
             hours_cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
 
+        # --- Heartbeat thread ---
+        # Emits a "still working" progress line every _HEARTBEAT_INTERVAL_SECONDS
+        # so operators can confirm the pipeline is alive during long runs.
+        # The lambda captures the counter variables by reference so the thread
+        # always reads the current values.
+        _current_stage = ["starting"]
+
+        def _heartbeat_counts() -> tuple[int, int, str]:
+            return (scored, fetched, _current_stage[0])
+
+        _heartbeat_stop = threading.Event()
+        _heartbeat = _HeartbeatThread(
+            stop_event=_heartbeat_stop,
+            interval_seconds=_HEARTBEAT_INTERVAL_SECONDS,
+            get_counts=_heartbeat_counts,
+        )
+        _heartbeat.start()
+
         for client in sources:
             logger.info("Fetching from source: %s", client.SOURCE)
             for page in _safe_pages(client):
@@ -1398,6 +1520,7 @@ def run(
                         # API.  If the source also sets description_is_full=True AND the
                         # description is long enough (>= _SCRAPE_MIN_LENGTH), classify
                         # as "full"; otherwise fall back to "snippet".
+                        _current_stage[0] = "scraping"
                         if listing.get("skip_scrape"):
                             scraped_skipped += 1
                             if (listing.get("description_is_full")
@@ -1422,6 +1545,7 @@ def run(
                             listing["description"] = description
 
                         # --- Score ---
+                        _current_stage[0] = "scoring"
                         score_result = score_listing_with_fallback(
                             listing=listing,
                             profile=profile,
@@ -1540,6 +1664,10 @@ def run(
                             src_name,
                             title,
                         )
+
+        # Stop the heartbeat now that the source loop is done.
+        _heartbeat_stop.set()
+        _heartbeat.join(timeout=5.0)
 
         total_tokens = total_tokens_input + total_tokens_output
         run_cost = sum(b["cost"] for b in provider_costs.values())

--- a/tests/test_ingest_observability.py
+++ b/tests/test_ingest_observability.py
@@ -1,0 +1,339 @@
+"""tests/test_ingest_observability.py — Regression tests for issue #602.
+
+Covers three observability improvements added to ingest.py and db.py:
+
+1. Log flushing  — FileHandler subclass flushes after every record.
+2. Pool wait timeout — db.get_connection() raises PoolWaitTimeout when
+   the connection pool is exhausted and the wait exceeds the configured
+   timeout.
+3. Heartbeat logging — the background heartbeat thread emits a
+   progress line at a configurable cadence.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _root_handler_cleanup(root: logging.Logger, before: list) -> None:
+    """Remove any handler added to *root* that was not present in *before*."""
+    for h in list(root.handlers):
+        if h not in before:
+            root.removeHandler(h)
+            try:
+                h.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+# ---------------------------------------------------------------------------
+# 1. Log flushing — ImmediateFlushHandler
+# ---------------------------------------------------------------------------
+
+class TestImmediateFlushHandler:
+    """The FileHandler used in _configure_file_logging() must flush on emit."""
+
+    def test_handler_exists(self) -> None:
+        """ingest module must export ImmediateFlushHandler."""
+        import ingest
+        assert hasattr(ingest, "ImmediateFlushHandler"), (
+            "Expected ingest.ImmediateFlushHandler to exist"
+        )
+
+    def test_is_file_handler_subclass(self) -> None:
+        """ImmediateFlushHandler must be a FileHandler subclass."""
+        import ingest
+        assert issubclass(ingest.ImmediateFlushHandler, logging.FileHandler)
+
+    def test_flush_called_on_emit(self, tmp_path: pytest.TempdirFactory) -> None:
+        """emit() must call flush() so each log record lands on disk immediately."""
+        import ingest
+        log_file = tmp_path / "test.log"
+        handler = ingest.ImmediateFlushHandler(str(log_file), encoding="utf-8")
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        flush_calls: list[None] = []
+        original_flush = handler.flush
+
+        def recording_flush() -> None:
+            flush_calls.append(None)
+            original_flush()
+
+        handler.flush = recording_flush  # type: ignore[method-assign]
+
+        try:
+            record = logging.LogRecord(
+                name="test",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg="hello",
+                args=(),
+                exc_info=None,
+            )
+            handler.emit(record)
+        finally:
+            handler.close()
+
+        assert flush_calls, (
+            "expected flush() to be called at least once during emit()"
+        )
+
+    def test_configure_file_logging_uses_immediate_flush_handler(
+        self, tmp_path: pytest.TempdirFactory
+    ) -> None:
+        """_configure_file_logging() must attach an ImmediateFlushHandler."""
+        import ingest
+
+        root = logging.getLogger()
+        handlers_before = list(root.handlers)
+        try:
+            with patch("ingest._configure_file_logging.__module__"):
+                pass
+            # Call the real function with a tmp log dir
+            with patch("paths.get_log_dir", return_value=tmp_path):
+                ingest._configure_file_logging()
+
+            new_handlers = [
+                h for h in root.handlers if h not in handlers_before
+            ]
+            assert any(
+                isinstance(h, ingest.ImmediateFlushHandler)
+                for h in new_handlers
+            ), (
+                "Expected at least one ImmediateFlushHandler attached to root "
+                f"logger, got: {new_handlers}"
+            )
+        finally:
+            _root_handler_cleanup(root, handlers_before)
+
+
+# ---------------------------------------------------------------------------
+# 2. Pool wait timeout — PoolWaitTimeout + get_connection()
+# ---------------------------------------------------------------------------
+
+class TestPoolWaitTimeout:
+    """db.get_connection() must raise PoolWaitTimeout when the pool is
+    exhausted and the configured wait elapses."""
+
+    def test_pool_wait_timeout_exported(self) -> None:
+        """db module must expose PoolWaitTimeout."""
+        import db
+        assert hasattr(db, "PoolWaitTimeout"), (
+            "Expected db.PoolWaitTimeout to exist"
+        )
+
+    def test_pool_wait_timeout_is_exception(self) -> None:
+        """PoolWaitTimeout must be an Exception subclass."""
+        import db
+        assert issubclass(db.PoolWaitTimeout, Exception)
+
+    def test_raises_when_pool_exhausted(self) -> None:
+        """get_connection() raises PoolWaitTimeout promptly when getconn() blocks."""
+        import db
+
+        # Simulate an exhausted pool by making getconn() block indefinitely.
+        blocking_event = threading.Event()
+
+        def _blocking_getconn(*_args, **_kwargs):
+            # Block until the test tells us the timeout has already fired.
+            blocking_event.wait(timeout=10)
+            raise Exception("should not reach here in normal test flow")
+
+        mock_pool = MagicMock()
+        mock_pool.getconn.side_effect = _blocking_getconn
+
+        start = time.monotonic()
+        try:
+            with patch("db._get_pool", return_value=mock_pool):
+                with pytest.raises(db.PoolWaitTimeout):
+                    # Pass a very short timeout so the test finishes quickly.
+                    db.get_connection(pool_wait_timeout=0.3)
+        finally:
+            blocking_event.set()  # unblock the background thread
+
+        elapsed = time.monotonic() - start
+        # Should fail within ~2x the timeout, not after a long hang.
+        assert elapsed < 3.0, (
+            f"get_connection() took {elapsed:.2f}s — expected < 3s for a 0.3s timeout"
+        )
+
+    def test_raises_promptly(self) -> None:
+        """PoolWaitTimeout must fire close to the configured timeout, not much later."""
+        import db
+
+        def _blocking_getconn(*_args, **_kwargs):
+            time.sleep(10)  # simulate infinite block
+
+        mock_pool = MagicMock()
+        mock_pool.getconn.side_effect = _blocking_getconn
+
+        start = time.monotonic()
+        with patch("db._get_pool", return_value=mock_pool):
+            with pytest.raises(db.PoolWaitTimeout):
+                db.get_connection(pool_wait_timeout=0.25)
+
+        elapsed = time.monotonic() - start
+        # Allow 2x headroom for CI jitter, but not 10s of hang.
+        assert elapsed < 2.0, (
+            f"Timeout took {elapsed:.2f}s; expected < 2.0s for a 0.25s timeout"
+        )
+
+    def test_succeeds_when_pool_not_exhausted(self) -> None:
+        """get_connection() returns normally when getconn() succeeds promptly."""
+        import db
+
+        mock_conn = MagicMock()
+        mock_conn.autocommit = False
+        mock_pool = MagicMock()
+        mock_pool.getconn.return_value = mock_conn
+
+        with patch("db._get_pool", return_value=mock_pool):
+            conn = db.get_connection(pool_wait_timeout=5.0)
+
+        assert conn is not None
+        mock_pool.getconn.assert_called_once()
+
+    def test_default_timeout_is_bounded(self) -> None:
+        """The default pool_wait_timeout must be a positive finite number."""
+        import db
+        assert hasattr(db, "POOL_WAIT_TIMEOUT_SECONDS"), (
+            "Expected db.POOL_WAIT_TIMEOUT_SECONDS to exist"
+        )
+        assert db.POOL_WAIT_TIMEOUT_SECONDS > 0
+        assert db.POOL_WAIT_TIMEOUT_SECONDS < 300  # sanity — no more than 5 min
+
+
+# ---------------------------------------------------------------------------
+# 3. Heartbeat logging
+# ---------------------------------------------------------------------------
+
+class TestHeartbeat:
+    """The _HeartbeatThread helper must log at the configured cadence."""
+
+    def test_heartbeat_class_exported(self) -> None:
+        """ingest module must expose _HeartbeatThread."""
+        import ingest
+        assert hasattr(ingest, "_HeartbeatThread"), (
+            "Expected ingest._HeartbeatThread to exist"
+        )
+
+    def test_heartbeat_is_daemon(self) -> None:
+        """_HeartbeatThread must run as a daemon so it does not block process exit."""
+        import ingest
+        stop_evt = threading.Event()
+        hb = ingest._HeartbeatThread(
+            stop_event=stop_evt,
+            interval_seconds=60,
+            get_counts=lambda: (0, 0, "idle"),
+        )
+        assert hb.daemon, "_HeartbeatThread must be a daemon thread"
+
+    def test_heartbeat_logs_at_configured_interval(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """_HeartbeatThread must emit at least one heartbeat within 2x its interval."""
+        import ingest
+
+        stop_evt = threading.Event()
+        heartbeat_fired = threading.Event()
+
+        def _get_counts():
+            return (5, 20, "scoring")
+
+        # Use a very short interval so the test finishes quickly.
+        hb = ingest._HeartbeatThread(
+            stop_event=stop_evt,
+            interval_seconds=0.1,
+            get_counts=_get_counts,
+        )
+
+        with caplog.at_level(logging.INFO, logger="ingest"):
+            hb.start()
+            # Wait up to 1s for at least one heartbeat message.
+            deadline = time.monotonic() + 1.0
+            while time.monotonic() < deadline:
+                if any(
+                    "heartbeat" in r.message.lower()
+                    or "still working" in r.message.lower()
+                    or "processed" in r.message.lower()
+                    for r in caplog.records
+                ):
+                    heartbeat_fired.set()
+                    break
+                time.sleep(0.02)
+            stop_evt.set()
+            hb.join(timeout=2.0)
+
+        assert heartbeat_fired.is_set(), (
+            f"No heartbeat log emitted within 1s. Records: {caplog.records}"
+        )
+
+    def test_heartbeat_stops_on_event(self) -> None:
+        """_HeartbeatThread must stop running after stop_event is set."""
+        import ingest
+
+        stop_evt = threading.Event()
+
+        hb = ingest._HeartbeatThread(
+            stop_event=stop_evt,
+            interval_seconds=0.05,
+            get_counts=lambda: (1, 10, "scraping"),
+        )
+        hb.start()
+        stop_evt.set()
+        hb.join(timeout=2.0)
+
+        assert not hb.is_alive(), (
+            "_HeartbeatThread is still alive after stop_event was set"
+        )
+
+    def test_heartbeat_includes_progress_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Heartbeat messages must include scored/fetched counts and stage."""
+        import ingest
+
+        stop_evt = threading.Event()
+
+        def _get_counts():
+            return (7, 42, "scraping")
+
+        hb = ingest._HeartbeatThread(
+            stop_event=stop_evt,
+            interval_seconds=0.05,
+            get_counts=_get_counts,
+        )
+        with caplog.at_level(logging.INFO, logger="ingest"):
+            hb.start()
+            time.sleep(0.3)
+            stop_evt.set()
+            hb.join(timeout=2.0)
+
+        heartbeat_records = [
+            r for r in caplog.records
+            if (
+                "heartbeat" in r.message.lower()
+                or "still working" in r.message.lower()
+                or "processed" in r.message.lower()
+            )
+        ]
+        assert heartbeat_records, "No heartbeat records emitted"
+        # At least one record should contain count/stage info.
+        combined = " ".join(r.message for r in heartbeat_records)
+        assert "7" in combined or "42" in combined or "scraping" in combined, (
+            f"Heartbeat messages do not appear to include progress info: {combined}"
+        )

--- a/tests/test_log_file_permission_fallback.py
+++ b/tests/test_log_file_permission_fallback.py
@@ -27,7 +27,7 @@ def reset_root_logger():
 def test_no_raise_on_permission_error(tmp_path, monkeypatch):
     """Function must not raise when FileHandler raises PermissionError."""
     monkeypatch.setenv("LOG_DIR", str(tmp_path))
-    with patch("logging.FileHandler", side_effect=PermissionError("Permission denied")):
+    with patch("ingest.ImmediateFlushHandler", side_effect=PermissionError("Permission denied")):
         # Should complete silently — no exception propagated.
         _configure_file_logging()
 
@@ -35,7 +35,7 @@ def test_no_raise_on_permission_error(tmp_path, monkeypatch):
 def test_warning_logged_on_permission_error(tmp_path, monkeypatch, caplog):
     """A WARNING containing 'File logging unavailable' must be emitted."""
     monkeypatch.setenv("LOG_DIR", str(tmp_path))
-    with patch("logging.FileHandler", side_effect=PermissionError("Permission denied")):
+    with patch("ingest.ImmediateFlushHandler", side_effect=PermissionError("Permission denied")):
         with caplog.at_level(logging.WARNING):
             _configure_file_logging()
 
@@ -52,7 +52,7 @@ def test_no_file_handler_added_on_permission_error(tmp_path, monkeypatch):
     root_logger = logging.getLogger()
     handlers_before = list(root_logger.handlers)
 
-    with patch("logging.FileHandler", side_effect=PermissionError("Permission denied")):
+    with patch("ingest.ImmediateFlushHandler", side_effect=PermissionError("Permission denied")):
         _configure_file_logging()
 
     file_handlers_after = [
@@ -67,7 +67,7 @@ def test_no_file_handler_added_on_permission_error(tmp_path, monkeypatch):
 def test_no_raise_on_oserror(tmp_path, monkeypatch):
     """Function must not raise when FileHandler raises OSError."""
     monkeypatch.setenv("LOG_DIR", str(tmp_path))
-    with patch("logging.FileHandler", side_effect=OSError("Read-only file system")):
+    with patch("ingest.ImmediateFlushHandler", side_effect=OSError("Read-only file system")):
         _configure_file_logging()
 
 


### PR DESCRIPTION
## Summary

- **Log flushing**: `ImmediateFlushHandler` (a `logging.FileHandler` subclass) calls `flush()` after every `emit()`. `_configure_file_logging()` now uses it, so log output lands on disk immediately during long pipeline runs rather than buffering silently.

- **Pool wait timeout**: `db.get_connection()` now accepts a `pool_wait_timeout` parameter (default `POOL_WAIT_TIMEOUT_SECONDS = 30`). A daemon thread runs `pool.getconn()` and the result is received via `queue.Queue.get(timeout=...)`. When the pool is exhausted and the timeout elapses, `PoolWaitTimeout` is raised promptly instead of hanging forever.

- **Main-loop heartbeat**: `_HeartbeatThread` is a daemon thread started at the top of the ingest source loop. It logs `"Heartbeat — still working: N/M listings processed, current stage=X"` every `_HEARTBEAT_INTERVAL_SECONDS` (default 30 s), configurable at construction time. It stops cleanly when the source loop completes.

## Tests

- `tests/test_ingest_observability.py` — 15 new regression tests covering all three improvements.
- `tests/test_log_file_permission_fallback.py` — updated 3 mock targets from `logging.FileHandler` to `ingest.ImmediateFlushHandler` (the implementation now instantiates the subclass, not the base directly).

## Verification

- `ruff check .` → clean (0 violations)
- `pytest` → 2150 passed, 1 skipped (baseline was 2135 passed, 1 skipped — 15 new tests added, 0 regressions)

Closes #602

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_