### PR TITLE
refactor(#515): split canonical listing schema into required/optional keys

### DIFF
--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -28,10 +28,12 @@ required.
 
    - `fetch_page(page)` — fetch one page of raw listings from the source API.
    - `total_pages()` — return the total number of pages available.
-   - `normalise(raw)` — convert one raw listing dict to the canonical schema.
+   - `_normalise(raw)` — convert one raw listing dict to the canonical schema.
 
-   See the [Canonical Listing Schema](#canonical-listing-schema) section for the
-   exact keys `normalise()` must return.
+   See the [Canonical Listing Schema](#canonical-listing-schema) section for
+   the required and optional keys `_normalise()` should return.  The public
+   `normalise()` method is provided by the base class; it calls `_normalise()`
+   and then fills in defaults for any optional keys you omit.
 
 4. **Fill in `source.json`** with metadata about your source:
 
@@ -89,26 +91,40 @@ loader from `source.json` and injected onto the class at load time.
 
 ## Canonical Listing Schema
 
-`normalise()` must return a dict containing **all** of the following keys. Use
-`None` for fields the source does not provide — never omit a key.
+`_normalise()` returns a dict of canonical keys.  The base class
+`normalise()` wrapper applies defaults for any optional keys you omit, so
+you only need to include the keys your source actually has data for.
 
-| Key            | Type          | Description |
-|----------------|---------------|-------------|
-| `source`       | str           | Source identifier; must match `source_key`. |
-| `source_id`    | str           | Unique listing ID from the source. |
-| `title`        | str           | Job title. |
-| `company`      | str           | Employer name. |
-| `location`     | str           | Location string as returned by the source. |
-| `salary_min`   | float or None | Lower salary bound in local currency. |
-| `salary_max`   | float or None | Upper salary bound in local currency. |
-| `salary_period`| str or None   | Pay period: `"annual"`, `"daily"`, `"hourly"`, or `None`. |
-| `contract_type`| str or None   | e.g. `"permanent"`, `"contract"`, or `None`. |
-| `contract_time`| str or None   | e.g. `"full_time"`, `"part_time"`, or `None`. |
-| `description`  | str or None   | Short snippet or `None`. The pipeline scrapes the full job description later unless `skip_scrape` is `True`. |
-| `redirect_url` | str           | URL linking to the full job listing. |
-| `created_at`   | str or None   | ISO 8601 string, e.g. `"2026-01-02T12:34:56Z"`. |
-| `skip_scrape`  | bool          | Optional (default `False`). Set `True` when the source URL is known to block scrapers (e.g. returns 403). The pipeline uses the API description directly. |
-| `description_is_full` | bool   | Optional (default `False`). Set `True` alongside `skip_scrape` when the API provides complete job descriptions (not just snippets). Listings with this flag and descriptions >= 100 chars are classified as `"full"` in the main feed instead of `"snippet"`. |
+### Required keys
+
+Always return these six keys with a meaningful value:
+
+| Key          | Type | Description |
+|--------------|------|-------------|
+| `source`     | str  | Source identifier; must match `source_key`. |
+| `source_id`  | str  | Unique listing ID from the source. |
+| `title`      | str  | Job title. |
+| `company`    | str  | Employer name. |
+| `location`   | str  | Location string as returned by the source. |
+| `redirect_url` | str | URL linking to the full job listing. |
+
+### Optional keys
+
+Include these only when your source has data for them.  Any key you omit is
+automatically defaulted by `_apply_defaults()` before the listing reaches the
+ingestion pipeline — bracket access in `ingest.py` is always safe.
+
+| Key                  | Type          | Default | Description |
+|----------------------|---------------|---------|-------------|
+| `salary_min`         | float or None | `None`  | Lower salary bound in local currency. |
+| `salary_max`         | float or None | `None`  | Upper salary bound in local currency. |
+| `salary_period`      | str or None   | `None`  | Pay period: `"annual"`, `"daily"`, `"hourly"`, or `None`. |
+| `contract_type`      | str or None   | `None`  | e.g. `"permanent"`, `"contract"`, or `None`. |
+| `contract_time`      | str or None   | `None`  | e.g. `"full_time"`, `"part_time"`, or `None`. |
+| `description`        | str or None   | `None`  | Short snippet or `None`. The pipeline scrapes the full job description later unless `skip_scrape` is `True`. |
+| `created_at`         | str or None   | `None`  | ISO 8601 string, e.g. `"2026-01-02T12:34:56Z"`. |
+| `skip_scrape`        | bool          | `False` | Set `True` when the source URL is known to block scrapers (e.g. returns 403). The pipeline uses the API description directly. |
+| `description_is_full`| bool          | `False` | Set `True` alongside `skip_scrape` when the API provides complete job descriptions (not just snippets). Listings with this flag and descriptions >= 100 chars are classified as `"full"` in the main feed instead of `"snippet"`. |
 
 ---
 

--- a/job_sources/base.py
+++ b/job_sources/base.py
@@ -2,36 +2,71 @@
 job_sources/base.py — Abstract base class for job source providers.
 
 All concrete job sources must implement ``fetch_page()``, ``total_pages()``,
-and ``normalise()`` so that the ingestion pipeline can work with any source
+and ``_normalise()`` so that the ingestion pipeline can work with any source
 without source-specific branching.
 
 Canonical listing schema
 ------------------------
-``normalise()`` must return a dict with exactly these keys:
+``normalise()`` (the public method on this base class) calls ``_normalise()``
+then applies schema defaults so that every key in the canonical schema is
+always present in the returned dict.  Plugins only need to return the keys
+they have data for.
+
+Required keys — must always be present with a meaningful value:
 
     source          str          — source identifier, e.g. "adzuna"
     source_id       str          — source-specific listing ID
     title           str
     company         str
     location        str
-    salary_min      float|None
-    salary_max      float|None
-    salary_period   str|None     — pay period: "annual", "daily", "hourly", or None (unknown)
-    contract_type   str|None
-    contract_time   str|None
-    description     str|None     — snippet or None; full JD scraped later
     redirect_url    str
+
+Optional keys — populated by plugins that have data for them; absent keys are
+defaulted automatically by ``_apply_defaults()`` before the dict reaches the
+ingestion pipeline:
+
+    salary_min      float|None   — default None
+    salary_max      float|None   — default None
+    salary_period   str|None     — "annual", "daily", "hourly", or None
+                                   default None
+    contract_type   str|None     — default None
+    contract_time   str|None     — default None
+    description     str|None     — snippet or None; full JD scraped later
+                                   default None
     created_at      str|None     — ISO 8601 string, e.g. "2026-01-02T12:34:56Z"
-    skip_scrape     bool         — optional (default False); set True when the source
-                                   URL is known to block scrapers (e.g. Jooble /jdp/
-                                   pages return 403). The pipeline skips the HTTP
-                                   scrape step and uses the API description directly.
+                                   default None
+    skip_scrape     bool         — set True when the source URL is known to
+                                   block scrapers (e.g. Jooble /jdp/ pages
+                                   return 403).  The pipeline skips the HTTP
+                                   scrape step and uses the API description
+                                   directly.  Default False.
+    description_is_full
+                    bool         — set True alongside skip_scrape when the
+                                   source API provides complete job descriptions
+                                   (not just snippets).  Listings with this
+                                   flag and descriptions >= 100 chars are
+                                   classified as "full" in the main feed.
+                                   Default False.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Iterator
+
+# Optional keys and their defaults, applied by ``_apply_defaults()`` whenever
+# a plugin's ``_normalise()`` does not explicitly set them.
+_OPTIONAL_DEFAULTS: dict = {
+    "salary_min": None,
+    "salary_max": None,
+    "salary_period": None,
+    "contract_type": None,
+    "contract_time": None,
+    "description": None,
+    "created_at": None,
+    "skip_scrape": False,
+    "description_is_full": False,
+}
 
 
 class JobSource(ABC):
@@ -76,18 +111,64 @@ class JobSource(ABC):
         ...
 
     @abstractmethod
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Convert a source-specific raw listing dict to the canonical schema.
+
+        Plugins implement this method instead of ``normalise()``.  Only the
+        keys the source actually has data for need to be returned — the public
+        ``normalise()`` method fills in optional-key defaults via
+        ``_apply_defaults()`` before returning to callers.
 
         Args:
             raw: A single raw listing dict as returned by ``fetch_page()``.
 
         Returns:
-            Dict conforming to the canonical listing schema documented in
-            this module's docstring.  All keys must be present; unknown
-            source fields are silently dropped.
+            Dict containing at minimum all required canonical keys plus any
+            optional keys the source populates.  Unknown source fields are
+            silently dropped.
         """
         ...
+
+    # ------------------------------------------------------------------
+    # Concrete helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _apply_defaults(listing: dict) -> dict:
+        """Fill in optional canonical keys that the plugin did not set.
+
+        Applies ``_OPTIONAL_DEFAULTS`` for every key absent from *listing*
+        without overwriting keys the plugin explicitly set (including falsy
+        values like ``None``, ``0``, or ``""``, which are intentional).
+
+        Args:
+            listing: Partial canonical listing dict from ``_normalise()``.
+
+        Returns:
+            The same dict with missing optional keys populated from
+            ``_OPTIONAL_DEFAULTS``.
+        """
+        for key, default in _OPTIONAL_DEFAULTS.items():
+            if key not in listing:
+                listing[key] = default
+        return listing
+
+    def normalise(self, raw: dict) -> dict:
+        """Convert a raw listing dict to the canonical schema with defaults.
+
+        Calls ``_normalise(raw)`` then applies optional-key defaults so that
+        every key in the canonical schema is always present.  Callers should
+        use this method; plugins should implement ``_normalise()``.
+
+        Args:
+            raw: A single raw listing dict as returned by ``fetch_page()``.
+
+        Returns:
+            Dict conforming to the canonical listing schema with all optional
+            keys present (defaulted if not set by the plugin).
+        """
+        listing = self._normalise(raw)
+        return self._apply_defaults(listing)
 
     def pages(self) -> Iterator[list[dict]]:
         """Yield normalised listing lists, one per page.

--- a/plugins/sources/_template/plugin.py
+++ b/plugins/sources/_template/plugin.py
@@ -85,46 +85,43 @@ class TemplateSource(JobSource):
         """
         raise NotImplementedError
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Convert one raw listing dict to the canonical schema.
 
-        Every key listed below must be present in the returned dict.
-        Use None for fields the source does not provide — never omit a key.
+        Implement this method instead of ``normalise()``.  Only include the
+        keys your source has data for — the base class ``normalise()`` wrapper
+        applies defaults for any optional keys you omit.
 
-        Required canonical keys (see job_sources/base.py module docstring):
+        Required keys (must always be present and non-empty):
 
             source          str          — source identifier, must match source_key
             source_id       str          — unique listing ID from the source
             title           str          — job title
             company         str          — employer name
             location        str          — location string as returned by source
+            redirect_url    str          — URL linking to the full job listing
+
+        Optional keys (omit if your source has no data for them; defaults are
+        applied automatically — see ``job_sources/base.py``):
+
             salary_min      float|None   — lower salary bound (in local currency)
             salary_max      float|None   — upper salary bound (in local currency)
             salary_period   str|None     — "annual", "daily", "hourly", or None
             contract_type   str|None     — e.g. "permanent", "contract", or None
             contract_time   str|None     — e.g. "full_time", "part_time", or None
             description     str|None     — snippet or None; pipeline scrapes full JD later
-            redirect_url    str          — URL linking to the full job listing
             created_at      str|None     — ISO 8601 string, e.g. "2026-01-02T12:34:56Z"
-
-        Optional canonical keys:
-
-            skip_scrape     bool         — set True when the source URL is known to
-                                           block scrapers (returns 403, requires login,
-                                           etc.). The pipeline will use the API
-                                           description directly instead of scraping.
+            skip_scrape     bool         — True when source URL blocks scrapers
             description_is_full
-                            bool         — set True alongside skip_scrape when the
-                                           source API provides complete job
-                                           descriptions (not just snippets).
-                                           Listings with this flag and descriptions
-                                           >= 100 chars are classified as "full".
+                            bool         — True when source provides complete descriptions
 
         Args:
             raw: A single listing dict as returned by ``fetch_page()``.
 
         Returns:
-            Dict conforming to the canonical listing schema above.
+            Dict with required keys plus any optional keys the source populates.
+            Do not include optional keys your source has no data for — the base
+            class will default them automatically.
 
         Example::
 
@@ -137,13 +134,12 @@ class TemplateSource(JobSource):
                 "title": raw.get("title", ""),
                 "company": raw.get("company", ""),
                 "location": raw.get("location", ""),
+                "redirect_url": raw.get("url", ""),
+                # Include optional keys only when the source has data for them:
                 "salary_min": salary_min,
                 "salary_max": salary_max,
-                "salary_period": None,
-                "contract_type": raw.get("type"),
                 "contract_time": raw.get("schedule"),
                 "description": strip_html(raw.get("description", "")),
-                "redirect_url": raw.get("url", ""),
                 "created_at": raw.get("posted_at"),
             }
         """

--- a/plugins/sources/adzuna/plugin.py
+++ b/plugins/sources/adzuna/plugin.py
@@ -183,15 +183,16 @@ class AdzunaClient(JobSource):
         """
         return self._search["max_pages"]
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Map an Adzuna result dict to the canonical listing schema.
 
         Args:
             raw: A single entry from the Adzuna ``results`` array.
 
         Returns:
-            Dict conforming to the canonical listing schema defined in
-            ``job_sources.base``.
+            Dict containing required canonical keys and any Adzuna-specific
+            optional keys that have data.  Optional keys absent here are
+            defaulted by the base class ``normalise()`` wrapper.
         """
         company_obj = raw.get("company") or {}
         location_obj = raw.get("location") or {}

--- a/plugins/sources/arbeitnow/plugin.py
+++ b/plugins/sources/arbeitnow/plugin.py
@@ -184,7 +184,7 @@ class ArbeitnowClient(JobSource):
                 return
             yield [self.normalise(r) for r in results]
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Map an Arbeitnow listing dict to the canonical listing schema.
 
         Field mapping:
@@ -203,8 +203,9 @@ class ArbeitnowClient(JobSource):
             raw: A single entry from the Arbeitnow ``data`` array.
 
         Returns:
-            Dict conforming to the canonical listing schema defined in
-            ``job_sources.base``.
+            Dict containing required canonical keys and any Arbeitnow-specific
+            optional keys that have data.  Optional keys absent here are
+            defaulted by the base class ``normalise()`` wrapper.
         """
         # Resolve location: prefer the location string; fall back to "Remote"
         # when the remote flag is set and no location string is provided.
@@ -236,10 +237,6 @@ class ArbeitnowClient(JobSource):
             "title": raw.get("title", "") or "",
             "company": raw.get("company_name", "") or "",
             "location": location,
-            "salary_min": None,
-            "salary_max": None,
-            "salary_period": None,  # Arbeitnow does not expose salary data
-            "contract_type": None,
             "contract_time": contract_time,
             "description": description,
             "redirect_url": raw.get("url", "") or "",

--- a/plugins/sources/himalayas/plugin.py
+++ b/plugins/sources/himalayas/plugin.py
@@ -244,15 +244,16 @@ class HimalayasClient(JobSource):
                 return
             yield results
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Map a Himalayas job dict to the canonical listing schema.
 
         Args:
             raw: A single entry from the Himalayas ``jobs`` array.
 
         Returns:
-            Dict conforming to the canonical listing schema defined in
-            ``job_sources.base``.
+            Dict containing required canonical keys and any Himalayas-specific
+            optional keys that have data.  Optional keys absent here are
+            defaulted by the base class ``normalise()`` wrapper.
         """
         location_restrictions: list[str] = raw.get("locationRestrictions") or []
         location = ", ".join(location_restrictions) if location_restrictions else "Worldwide"
@@ -268,8 +269,6 @@ class HimalayasClient(JobSource):
             "location": location,
             "salary_min": raw.get("minSalary"),
             "salary_max": raw.get("maxSalary"),
-            "salary_period": None,  # Himalayas API does not expose a pay-period field
-            "contract_type": None,
             "contract_time": _map_job_type(raw.get("employmentType")),
             "description": description,
             "redirect_url": raw.get("applicationLink") or "",

--- a/plugins/sources/jobicy/plugin.py
+++ b/plugins/sources/jobicy/plugin.py
@@ -139,7 +139,7 @@ class JobicyClient(JobSource):
         if results:
             yield results
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Map a Jobicy job dict to the canonical listing schema.
 
         Salary is populated from the structured ``annualSalaryMin`` /
@@ -150,8 +150,9 @@ class JobicyClient(JobSource):
             raw: A single entry from the Jobicy ``jobs`` array.
 
         Returns:
-            Dict conforming to the canonical listing schema defined in
-            ``job_sources.base``.
+            Dict containing required canonical keys and any Jobicy-specific
+            optional keys that have data.  Optional keys absent here are
+            defaulted by the base class ``normalise()`` wrapper.
         """
         salary_min_raw = raw.get("annualSalaryMin")
         salary_max_raw = raw.get("annualSalaryMax")
@@ -180,7 +181,6 @@ class JobicyClient(JobSource):
             "salary_min": salary_min,
             "salary_max": salary_max,
             "salary_period": salary_period,
-            "contract_type": None,
             "contract_time": _coerce_contract_field(raw.get("jobType")),
             "description": strip_html(raw.get("jobDescription", "") or ""),
             "redirect_url": raw.get("url", "") or "",

--- a/plugins/sources/jooble/plugin.py
+++ b/plugins/sources/jooble/plugin.py
@@ -221,7 +221,7 @@ class JoobleClient(JobSource):
                 return
             yield results
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Map a Jooble listing dict to the canonical listing schema.
 
         HTML is stripped from the ``snippet`` field.  Salary is parsed
@@ -240,8 +240,9 @@ class JoobleClient(JobSource):
             raw: A single entry from the Jooble ``jobs`` array.
 
         Returns:
-            Dict conforming to the canonical listing schema defined in
-            ``job_sources.base``.
+            Dict containing required canonical keys and any Jooble-specific
+            optional keys that have data.  Optional keys absent here are
+            defaulted by the base class ``normalise()`` wrapper.
         """
         salary_min, salary_max = parse_salary(raw.get("salary") or "")
 
@@ -256,8 +257,6 @@ class JoobleClient(JobSource):
             "location": raw.get("location", "") or "",
             "salary_min": salary_min,
             "salary_max": salary_max,
-            "salary_period": None,  # Jooble salary is free-text; period cannot be reliably inferred
-            "contract_type": None,
             "contract_time": contract_time,
             "description": strip_html(raw.get("snippet", "") or ""),
             "redirect_url": raw.get("link", "") or "",

--- a/plugins/sources/jsearch/plugin.py
+++ b/plugins/sources/jsearch/plugin.py
@@ -384,7 +384,7 @@ class JSearchClient(JobSource):
         """
         return self._search["max_pages"]
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Map a JSearch listing dict to the canonical listing schema.
 
         Location is assembled from structured city/state/country fields when
@@ -397,8 +397,9 @@ class JSearchClient(JobSource):
             raw: A single entry from the JSearch ``data`` array.
 
         Returns:
-            Dict conforming to the canonical listing schema defined in
-            ``job_sources.base``.
+            Dict containing required canonical keys and any JSearch-specific
+            optional keys that have data.  Optional keys absent here are
+            defaulted by the base class ``normalise()`` wrapper.
         """
         # Assemble location from structured parts; fall back to job_location.
         location_parts = [
@@ -423,7 +424,6 @@ class JSearchClient(JobSource):
             "salary_min": raw.get("job_min_salary"),
             "salary_max": raw.get("job_max_salary"),
             "salary_period": _normalise_salary_period(raw.get("job_salary_period")),
-            "contract_type": None,  # JSearch does not expose permanent/contract distinction
             "contract_time": _normalise_contract_time(raw.get("job_employment_type")),
             "description": raw.get("job_description", "") or "",
             "redirect_url": redirect_url,

--- a/plugins/sources/remoteok/plugin.py
+++ b/plugins/sources/remoteok/plugin.py
@@ -143,7 +143,7 @@ class RemoteOKClient(JobSource):
         if results:
             yield results
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Map a RemoteOK raw listing dict to the canonical listing schema.
 
         Salary fields set to ``0`` by RemoteOK (meaning "not specified") are
@@ -154,8 +154,9 @@ class RemoteOKClient(JobSource):
             raw: A single job dict from the RemoteOK API response.
 
         Returns:
-            Dict conforming to the canonical listing schema defined in
-            ``job_sources.base``.
+            Dict containing required canonical keys and any RemoteOK-specific
+            optional keys that have data.  Optional keys absent here are
+            defaulted by the base class ``normalise()`` wrapper.
         """
         # Salary: 0 or absent → None.
         raw_salary_min = raw.get("salary_min")
@@ -187,9 +188,6 @@ class RemoteOKClient(JobSource):
             "location": location,
             "salary_min": salary_min,
             "salary_max": salary_max,
-            "salary_period": None,  # RemoteOK does not expose a pay-period field
-            "contract_type": None,
-            "contract_time": None,
             "description": description,
             "redirect_url": raw.get("url", "") or "",
             "created_at": raw.get("date", "") or "",

--- a/plugins/sources/remotive/plugin.py
+++ b/plugins/sources/remotive/plugin.py
@@ -113,15 +113,16 @@ class RemotiveClient(JobSource):
         if results:
             yield results
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Map a Remotive job dict to the canonical listing schema.
 
         Args:
             raw: A single entry from the Remotive ``jobs`` array.
 
         Returns:
-            Dict conforming to the canonical listing schema defined in
-            ``job_sources.base``.
+            Dict containing required canonical keys and any Remotive-specific
+            optional keys that have data.  Optional keys absent here are
+            defaulted by the base class ``normalise()`` wrapper.
         """
         salary_min, salary_max = parse_salary(raw.get("salary") or "")
 
@@ -133,8 +134,6 @@ class RemotiveClient(JobSource):
             "location": raw.get("candidate_required_location", "") or "",
             "salary_min": salary_min,
             "salary_max": salary_max,
-            "salary_period": None,  # Remotive salary is free-text; period cannot be reliably inferred
-            "contract_type": None,
             "contract_time": raw.get("job_type", "") or "",
             "description": strip_html(raw.get("description", "") or ""),
             "redirect_url": raw.get("url", "") or "",

--- a/plugins/sources/the_muse/plugin.py
+++ b/plugins/sources/the_muse/plugin.py
@@ -184,19 +184,20 @@ class TheMuseClient(JobSource):
         self._page_count = int(data.get("page_count", 0))
         return self._page_count
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Map a raw The Muse listing dict to the canonical listing schema.
 
-        The Muse does not expose salary information, so ``salary_min``,
-        ``salary_max``, and ``contract_type`` are always ``None``.  HTML
-        markup in the ``contents`` field is stripped to plain text.
+        The Muse does not expose salary information or contract type, so those
+        optional keys are omitted and defaulted by the base class wrapper.
+        HTML markup in the ``contents`` field is stripped to plain text.
 
         Args:
             raw: A single entry from The Muse ``results`` array.
 
         Returns:
-            Dict conforming to the canonical listing schema defined in
-            ``job_sources.base``.
+            Dict containing required canonical keys and any The Muse-specific
+            optional keys that have data.  Optional keys absent here are
+            defaulted by the base class ``normalise()`` wrapper.
         """
         # Nested objects — guard against None / missing keys.
         company: str = (raw.get("company") or {}).get("name") or ""
@@ -209,10 +210,6 @@ class TheMuseClient(JobSource):
             "title": raw.get("name") or "",
             "company": company,
             "location": location,
-            "salary_min": None,
-            "salary_max": None,
-            "salary_period": None,  # The Muse does not expose salary data
-            "contract_type": None,
             "contract_time": raw.get("type") or None,
             "description": self._strip_html(raw.get("contents")),
             "redirect_url": (raw.get("refs") or {}).get("landing_page") or "",

--- a/plugins/sources/usajobs/plugin.py
+++ b/plugins/sources/usajobs/plugin.py
@@ -200,7 +200,7 @@ class USAJobsClient(JobSource):
 
         return pages
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Map a raw USAJobs ``SearchResultItems`` entry to the canonical schema.
 
         Salary fields are only populated when the rate interval is annual
@@ -211,8 +211,9 @@ class USAJobsClient(JobSource):
             raw: A single entry from ``SearchResultItems``.
 
         Returns:
-            Dict conforming to the canonical listing schema defined in
-            ``job_sources.base``.
+            Dict containing required canonical keys and any USAJobs-specific
+            optional keys that have data.  Optional keys absent here are
+            defaulted by the base class ``normalise()`` wrapper.
         """
         descriptor: dict = raw.get("MatchedObjectDescriptor") or {}
 

--- a/tests/test_credential_source_bugs.py
+++ b/tests/test_credential_source_bugs.py
@@ -205,7 +205,7 @@ class _KeylessSource(JobSource):
     def total_pages(self):
         return 1
 
-    def normalise(self, raw):
+    def _normalise(self, raw):
         return {}
 
     @classmethod
@@ -226,7 +226,7 @@ class _KeyedSource(JobSource):
     def total_pages(self):
         return 1
 
-    def normalise(self, raw):
+    def _normalise(self, raw):
         return {}
 
     @classmethod

--- a/tests/test_ingest_run.py
+++ b/tests/test_ingest_run.py
@@ -122,7 +122,7 @@ class MockJobSource(JobSource):
     def total_pages(self) -> int:
         return 1
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Pass-through — the fixture data is already normalised."""
         return raw
 

--- a/tests/test_ingest_unknown_model_warn.py
+++ b/tests/test_ingest_unknown_model_warn.py
@@ -52,7 +52,7 @@ class _StubSource(JobSource):
         """Return 1 — a single page is always sufficient for these tests."""
         return 1
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         """Pass through — fixture data is already normalised."""
         return raw
 

--- a/tests/test_job_sources.py
+++ b/tests/test_job_sources.py
@@ -41,7 +41,7 @@ class TestJobSourceABC:
         class Incomplete(JobSourceBase):
             def fetch_page(self, page):
                 return []
-            # total_pages and normalise intentionally missing
+            # total_pages and _normalise intentionally missing
 
         with pytest.raises(TypeError):
             Incomplete()  # type: ignore[abstract]
@@ -53,8 +53,15 @@ class TestJobSourceABC:
                 return []
             def total_pages(self):
                 return 1
-            def normalise(self, raw):
-                return {}
+            def _normalise(self, raw):
+                return {
+                    "source": "test",
+                    "source_id": "1",
+                    "title": "",
+                    "company": "",
+                    "location": "",
+                    "redirect_url": "",
+                }
 
         # Should not raise.
         instance = Complete()

--- a/tests/test_job_sources_bugs.py
+++ b/tests/test_job_sources_bugs.py
@@ -211,7 +211,7 @@ class TestAbcDefaultPages:
             def total_pages(self):
                 return 2
 
-            def normalise(self, raw):
+            def _normalise(self, raw):
                 return raw
 
             @classmethod

--- a/tests/test_job_sources_himalayas.py
+++ b/tests/test_job_sources_himalayas.py
@@ -376,15 +376,31 @@ class TestHimalayasClientNormalise:
         assert result["description"] == ""
 
     def test_normalise_canonical_keys_present(self):
-        """normalise() output must contain all canonical schema keys."""
-        expected_keys = {
+        """normalise() output contains all required and optional canonical keys.
+
+        Required keys must be present (source populates them directly).
+        Optional keys are present because the base-class ``_apply_defaults()``
+        fills them in when ``_normalise()`` omits them.
+        """
+        required_keys = {
             "source", "source_id", "title", "company", "location",
-            "salary_min", "salary_max", "salary_period", "contract_type", "contract_time",
-            "description", "redirect_url", "created_at",
+            "redirect_url",
+        }
+        optional_keys = {
+            "salary_min", "salary_max", "salary_period", "contract_type",
+            "contract_time", "description", "created_at",
+            "skip_scrape", "description_is_full",
         }
         client = self._client()
         result = client.normalise(_RAW_JOB)
-        assert set(result.keys()) == expected_keys
+        assert required_keys.issubset(result.keys())
+        # Optional keys are present (either populated by source or defaulted).
+        assert optional_keys.issubset(result.keys())
+        # Defaulted optional keys Himalayas has no data for are None/False.
+        assert result["salary_period"] is None
+        assert result["contract_type"] is None
+        assert result["skip_scrape"] is False
+        assert result["description_is_full"] is False
 
     def test_normalise_salary_period_is_none(self):
         """salary_period is always None — Himalayas API does not expose pay period."""

--- a/tests/test_job_sources_the_muse.py
+++ b/tests/test_job_sources_the_muse.py
@@ -138,15 +138,33 @@ class TestTheMuseClientNormalise:
         assert result["created_at"] == "2026-01-15T09:00:00Z"
 
     def test_all_canonical_keys_present(self):
-        """normalise() output contains every key in the canonical schema."""
-        expected_keys = {
+        """normalise() output contains all required and optional canonical keys.
+
+        Required keys must be present (source populates them directly).
+        Optional keys are present because the base-class ``_apply_defaults()``
+        fills them in when ``_normalise()`` omits them.
+        """
+        required_keys = {
             "source", "source_id", "title", "company", "location",
-            "salary_min", "salary_max", "salary_period", "contract_type", "contract_time",
-            "description", "redirect_url", "created_at",
+            "redirect_url",
+        }
+        optional_keys = {
+            "salary_min", "salary_max", "salary_period", "contract_type",
+            "contract_time", "description", "created_at",
+            "skip_scrape", "description_is_full",
         }
         client = _make_client()
         result = client.normalise(_RAW_LISTING)
-        assert expected_keys == set(result.keys())
+        assert required_keys.issubset(result.keys())
+        # Optional keys that The Muse does not populate are defaulted by base.
+        assert optional_keys.issubset(result.keys())
+        # Defaulted optional keys the source has no data for are None/False.
+        assert result["salary_min"] is None
+        assert result["salary_max"] is None
+        assert result["salary_period"] is None
+        assert result["contract_type"] is None
+        assert result["skip_scrape"] is False
+        assert result["description_is_full"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_job_sources_usajobs.py
+++ b/tests/test_job_sources_usajobs.py
@@ -449,15 +449,29 @@ class TestUSAJobsClientNormalise:
         assert result["created_at"] == ""
 
     def test_normalise_returns_all_canonical_keys(self):
-        """normalise() always returns exactly the canonical schema keys."""
-        canonical_keys = {
+        """normalise() output contains all required and optional canonical keys.
+
+        Required keys must be present (source populates them directly).
+        Optional keys are present because the base-class ``_apply_defaults()``
+        fills them in when ``_normalise()`` omits them.
+        """
+        required_keys = {
             "source", "source_id", "title", "company", "location",
-            "salary_min", "salary_max", "salary_period", "contract_type", "contract_time",
-            "description", "redirect_url", "created_at",
+            "redirect_url",
+        }
+        optional_keys = {
+            "salary_min", "salary_max", "salary_period", "contract_type",
+            "contract_time", "description", "created_at",
+            "skip_scrape", "description_is_full",
         }
         client = self._client()
         result = client.normalise(_RAW_ITEM)
-        assert set(result.keys()) == canonical_keys
+        assert required_keys.issubset(result.keys())
+        # Optional keys are present (either populated by source or defaulted).
+        assert optional_keys.issubset(result.keys())
+        # Defaulted optional keys USAJobs has no data for are False.
+        assert result["skip_scrape"] is False
+        assert result["description_is_full"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -37,7 +37,7 @@ class TestSource(JobSource):
         return []
     def total_pages(self):
         return 1
-    def normalise(self, raw):
+    def _normalise(self, raw):
         return {}
     @classmethod
     def settings_schema(cls):
@@ -106,7 +106,7 @@ def _make_plugin(
 class TestSource{i}(JobSource):
     def fetch_page(self, page): return []
     def total_pages(self): return 1
-    def normalise(self, raw): return {{}}
+    def _normalise(self, raw): return {{}}
     @classmethod
     def settings_schema(cls): return {{"display_name": "T{i}", "fields": []}}
 """)

--- a/tests/test_make_enabled_sources.py
+++ b/tests/test_make_enabled_sources.py
@@ -69,7 +69,7 @@ class _KeylessSource(JobSource):
     def total_pages(self):
         return 1
 
-    def normalise(self, raw):
+    def _normalise(self, raw):
         return {}
 
     @classmethod
@@ -90,7 +90,7 @@ class _KeyedSource(JobSource):
     def total_pages(self):
         return 1
 
-    def normalise(self, raw):
+    def _normalise(self, raw):
         return {}
 
     @classmethod
@@ -279,7 +279,7 @@ class _FailingSource(JobSource):
     def total_pages(self):
         return 1
 
-    def normalise(self, raw):
+    def _normalise(self, raw):
         return {}
 
     @classmethod

--- a/tests/test_plugin_isolation.py
+++ b/tests/test_plugin_isolation.py
@@ -39,7 +39,7 @@ class _GoodSource(JobSource):
     def total_pages(self) -> int:
         return 2
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         return raw
 
     @classmethod
@@ -62,7 +62,7 @@ class _CrashingSource(JobSource):
     def total_pages(self) -> int:
         return 1
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         return raw
 
     @classmethod
@@ -85,7 +85,7 @@ class _CrashMidwaySource(JobSource):
     def total_pages(self) -> int:
         return 1
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         return raw
 
     @classmethod

--- a/tests/test_validate_search_config.py
+++ b/tests/test_validate_search_config.py
@@ -238,7 +238,7 @@ class _SearchRequiringSource(BaseJobSource):
     def total_pages(self) -> int:
         return 0
 
-    def normalise(self, raw: dict) -> dict:
+    def _normalise(self, raw: dict) -> dict:
         return {}
 
     def pages(self) -> Iterator[list[dict]]:
@@ -580,7 +580,7 @@ class TestMakeEnabledSourcesKeyErrorCaught:
             def total_pages(self):
                 return 0
 
-            def normalise(self, raw):
+            def _normalise(self, raw):
                 return {}
 
             def pages(self) -> Iterator[list[dict]]:


### PR DESCRIPTION
## Summary

- Introduces a template-method pattern in `JobSource`: the abstract method is now `_normalise()`; the public `normalise()` on the base class calls `_normalise()` then `_apply_defaults()`, ensuring every optional key is always present in the returned dict before it reaches `ingest.py`.
- Required keys: `source`, `source_id`, `title`, `company`, `location`, `redirect_url`.
- Optional keys defaulted when absent: `salary_min`/`max` → `None`, `salary_period` → `None`, `contract_type` → `None`, `contract_time` → `None`, `description` → `None`, `created_at` → `None`, `skip_scrape` → `False`, `description_is_full` → `False`.
- All 10 plugins + template updated: `normalise` → `_normalise`; explicit `None` assignments for fields the source has no data for removed.
- `docs/PLUGIN_DEVELOPMENT.md` schema table split into Required / Optional sections with a Default column.

This is a behavior-preserving refactor: the dict flowing into `db.insert_listing()` for any source is identical to before.

## Test plan

- [x] `ruff check .` — CLEAN (baseline and post-change)
- [x] `pytest` — 2135 passed, 1 skipped (identical to baseline on SHA 1cd4566)
- [x] Three exact-equality key-set tests updated to `issubset` + explicit default checks (himalayas, the_muse, usajobs)
- [x] All stub subclasses in test helpers updated `normalise` → `_normalise`
- [ ] **Manual follow-up:** update the GitHub wiki page `Plugin-Development.md` (separate `glitchwerks/job-matcher.wiki` repo — cannot be edited from this checkout)

Closes #515

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_