### PR TITLE
fix(#365): add ingest mismatch warning for enabled-but-unloaded sources

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -39,7 +39,7 @@ from geopy.distance import geodesic
 from geopy.geocoders import Nominatim
 
 import db
-from job_sources import make_enabled_sources, get_required_search_fields
+from job_sources import make_enabled_sources, get_required_search_fields, get_sources
 from providers import build_provider_chain, LLMProvider
 from credentials import CredentialError, load_providers
 
@@ -1080,6 +1080,41 @@ def _inject_env_var_credentials(providers: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Source-registry mismatch helper
+# ---------------------------------------------------------------------------
+
+
+def _warn_source_mismatch(providers: dict) -> None:
+    """Warn when a source enabled in providers.json has no loaded plugin.
+
+    Compares the ``job_sources`` section of *providers* against the plugin
+    registry returned by :func:`~job_sources.get_sources`.  For every key
+    whose ``enabled`` flag is truthy but whose source key is absent from the
+    loaded registry, a ``WARNING`` is emitted on the ``"ingest"`` logger.
+
+    This is a startup diagnostic — it fires once per run so operators can
+    detect misconfigured or missing plugins before the ingest loop begins.
+    The actual per-source guard also lives inside
+    :func:`~job_sources.make_enabled_sources`; this function provides a
+    second, ingest-level signal that appears in the run banner.
+
+    Args:
+        providers: The providers dict loaded by ``load_providers()``.
+    """
+    loaded_keys: set[str] = set(get_sources().keys())
+    sources_cfg: dict = providers.get("job_sources") or {}
+    for key, src_cfg in sources_cfg.items():
+        if src_cfg.get("enabled") and key not in loaded_keys:
+            logger.warning(
+                "Source %r is enabled in providers.json but its plugin is "
+                "not loaded — check that plugins/sources/%s/ exists and "
+                "plugin.py is valid.",
+                key,
+                key,
+            )
+
+
+# ---------------------------------------------------------------------------
 # Plugin isolation helper
 # ---------------------------------------------------------------------------
 
@@ -1252,6 +1287,8 @@ def run(
 
         from job_sources.auto_register import ensure_plugins_registered
         ensure_plugins_registered(providers_path)
+
+        _warn_source_mismatch(providers)
 
         sources = make_enabled_sources(providers, config)
         if not sources:

--- a/tests/test_ingest_source_mismatch.py
+++ b/tests/test_ingest_source_mismatch.py
@@ -1,0 +1,151 @@
+"""
+tests/test_ingest_source_mismatch.py — Tests for ingest._warn_source_mismatch().
+
+Verifies that the startup diagnostic logs a warning when a source is enabled
+in providers.json but its plugin is not present in the loaded source registry,
+and that no warning is emitted when everything is consistent.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import ingest  # noqa: E402
+
+
+class TestWarnSourceMismatch:
+    """Unit tests for ingest._warn_source_mismatch()."""
+
+    def test_no_warning_when_all_enabled_sources_are_loaded(
+        self, monkeypatch, caplog
+    ):
+        """No warning when every enabled source key is in the plugin registry."""
+        monkeypatch.setattr(
+            "ingest.get_sources",
+            lambda: {"adzuna": object(), "remotive": object()},
+        )
+        providers = {
+            "job_sources": {
+                "adzuna": {"enabled": True},
+                "remotive": {"enabled": True},
+            }
+        }
+        with caplog.at_level(logging.WARNING, logger="ingest"):
+            ingest._warn_source_mismatch(providers)
+
+        assert caplog.records == []
+
+    def test_warning_emitted_for_enabled_source_not_in_registry(
+        self, monkeypatch, caplog
+    ):
+        """A warning is logged when an enabled source is absent from the registry."""
+        monkeypatch.setattr(
+            "ingest.get_sources",
+            lambda: {},  # registry has no plugins loaded
+        )
+        providers = {
+            "job_sources": {
+                "ghost_source": {"enabled": True},
+            }
+        }
+        with caplog.at_level(logging.WARNING, logger="ingest"):
+            ingest._warn_source_mismatch(providers)
+
+        assert len(caplog.records) == 1
+        assert "ghost_source" in caplog.records[0].message
+        assert "not loaded" in caplog.records[0].message
+
+    def test_no_warning_for_disabled_source_not_in_registry(
+        self, monkeypatch, caplog
+    ):
+        """Disabled sources that are absent from the registry do not warn."""
+        monkeypatch.setattr(
+            "ingest.get_sources",
+            lambda: {},
+        )
+        providers = {
+            "job_sources": {
+                "ghost_source": {"enabled": False},
+            }
+        }
+        with caplog.at_level(logging.WARNING, logger="ingest"):
+            ingest._warn_source_mismatch(providers)
+
+        assert caplog.records == []
+
+    def test_no_warning_when_job_sources_key_absent(
+        self, monkeypatch, caplog
+    ):
+        """An empty or missing job_sources section produces no warning."""
+        monkeypatch.setattr(
+            "ingest.get_sources",
+            lambda: {},
+        )
+        with caplog.at_level(logging.WARNING, logger="ingest"):
+            ingest._warn_source_mismatch({})
+
+        assert caplog.records == []
+
+    def test_multiple_missing_sources_each_warn(
+        self, monkeypatch, caplog
+    ):
+        """Each enabled-but-missing source emits its own warning."""
+        monkeypatch.setattr(
+            "ingest.get_sources",
+            lambda: {},
+        )
+        providers = {
+            "job_sources": {
+                "alpha": {"enabled": True},
+                "beta": {"enabled": True},
+            }
+        }
+        with caplog.at_level(logging.WARNING, logger="ingest"):
+            ingest._warn_source_mismatch(providers)
+
+        messages = [r.message for r in caplog.records]
+        assert any("alpha" in m for m in messages)
+        assert any("beta" in m for m in messages)
+
+    def test_source_present_in_registry_but_disabled_does_not_warn(
+        self, monkeypatch, caplog
+    ):
+        """A loaded source that is disabled does not produce a warning."""
+        monkeypatch.setattr(
+            "ingest.get_sources",
+            lambda: {"adzuna": object()},
+        )
+        providers = {
+            "job_sources": {
+                "adzuna": {"enabled": False},
+            }
+        }
+        with caplog.at_level(logging.WARNING, logger="ingest"):
+            ingest._warn_source_mismatch(providers)
+
+        assert caplog.records == []
+
+    def test_warning_message_mentions_plugin_path(
+        self, monkeypatch, caplog
+    ):
+        """The warning message includes the expected plugin directory path hint."""
+        monkeypatch.setattr(
+            "ingest.get_sources",
+            lambda: {},
+        )
+        providers = {
+            "job_sources": {
+                "my_plugin": {"enabled": True},
+            }
+        }
+        with caplog.at_level(logging.WARNING, logger="ingest"):
+            ingest._warn_source_mismatch(providers)
+
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert "my_plugin" in msg
+        assert "plugins/sources/my_plugin" in msg


### PR DESCRIPTION
## Summary

- Adds `_warn_source_mismatch()` to `ingest.py`: a startup diagnostic that compares `providers.json`'s `job_sources` section against the loaded plugin registry and emits a `WARNING` via the `"ingest"` logger for any source that is `enabled: true` but has no loaded plugin. Called in `run()` after `ensure_plugins_registered()`, before `make_enabled_sources()`, so the warning appears in the run banner.
- Adds `tests/test_ingest_source_mismatch.py` with 7 unit tests covering: enabled-but-missing warns, disabled-but-missing does not warn, loaded-but-disabled does not warn, empty providers no-op, multiple missing sources each warn individually, and warning message content.

## Verified as already shipped (no code changes needed)

The remaining items from the issue were audited against `main` @ `1cd4566` and found complete:

| Item | Status | Evidence |
|---|---|---|
| Remove dead `__abstractmethods__` manipulation | Already done | `grep __abstractmethods__ .` → no matches |
| `_log.debug` for underscore-prefix skip | Already done | `loader.py:85` |
| `fields` type validation (list of dicts, string `name` key) | Already done | `loader.py:138–165` |
| Reject empty/non-string `source_key` | Already done | `loader.py:121–127` |
| No shim files in `job_sources/` | Confirmed | Only `__init__.py`, `auto_register.py`, `base.py`, `loader.py`, `utils.py` |
| `get_sources()` replaces direct `SOURCES` in production | Confirmed | Only `auto_register.py` still imports `SOURCES` (intentional for monkeypatch compat) |
| Test patch targets use plugin path | Confirmed | All patches use `job_sources._plugin_<name>` form |

## Test plan

- [x] `ruff check .` → clean (pre- and post-change)
- [x] `pytest` → 2142 passed, 1 skipped (baseline 2135 passed, 1 skipped — net +7 new tests, zero regressions)
- [x] 7 new tests in `tests/test_ingest_source_mismatch.py` pass

Closes #365

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_