### PR TITLE
docs(design): vendor OpenDesign 2.0 handoff docs as UI fidelity anchor

### DIFF
--- a/docs/design/api-surface.md
+++ b/docs/design/api-surface.md
@@ -1,0 +1,183 @@
+# job-matcher — high-level API surface (root resources)
+
+> **Purpose.** A high-level map of the API the redesigned job-matcher needs — **root resources and
+> the operations they expose**, not specific paths or payload schemas. It exists to *seed* endpoint
+> design: it names the resources, says whether each is a singleton or a collection, lists the
+> domain actions beyond plain CRUD, and flags the genuine API-shape decisions still open.
+>
+> **Grounded in:** `docs/data-model.md §A` (the normative entity model — every resource below maps to
+> an entity there) and `docs/ui-layout.md` (the screens each resource backs). Repo reality (the
+> current Flask routes) is anchored to `I:\career\job-matcher` where cited.
+>
+> **Scope guard.** Root endpoints only. Where this doc says "actions," treat them as *capabilities the
+> resource must support*, not finalized verbs/paths — those are the next level down.
+
+---
+
+## 1. Assumptions & conventions
+
+These shape every resource below; if one is wrong, the map shifts — so they're stated up front, not buried.
+
+- **Single-user today.** The live app has exactly one profile (`data-model.md §1`). So **Candidate**
+  and **JobPreferences** are **singletons** — one resource instance, no ID, no list. Multi-user
+  (would scope everything under a user/account) is an **open decision** (§6), not assumed here.
+- **Three resource families.** *Config* (what the user sets up), *Content* (the data that flows
+  through — postings & resumes), *Runtime/Admin* (the scraping + scoring pipeline and its controls).
+  This mirrors the three-category IA (`data-model.md §0`) plus the Admin surface (`ui-layout.md §7`).
+- **The pipeline is asynchronous.** Ingest + LLM scoring are long-running (the live app already
+  streams an ingest drawer). So pipeline endpoints are **trigger + observe**, not request/response —
+  a `/jobs` read returns *current* state; making more jobs appear is an `/ingest` action you watch.
+- **Derived values are computed server-side and returned inline** (recommended — see §4/§6.1). A `Job`
+  comes back already carrying its salary-delta and per-role match data; a `Role` can be asked for its
+  *effective* (override-resolved) values. The alternative (client merges raw rows) is flagged in §6.
+
+---
+
+## 2. Resource map (the heart of this doc)
+
+| Root resource | Backing entity (`data-model.md`) | Shape | Core ops | Notable domain actions (beyond CRUD) |
+|---|---|---|---|---|
+| **`candidate`** | `Candidate` singleton (A.2) | singleton | read · replace · patch | import-from-PDF (LLM extract → prefill) |
+| **`candidate/skills`** | `Skill` bucket (A.3) | sub-collection | list · add · edit · remove | — (referenced by roles; deleting must handle role refs) |
+| **`roles`** | `Role` (A.4) | collection | list · create · read · update · delete | activate / **pause** · **duplicate** · read **effective** (resolved) values · scope feed to a role |
+| **`preferences`** | `JobPreferences` singleton (A.5) | singleton | read · replace · patch | — (changes re-scope ingestion filters) |
+| **`resumes`** | `Resume` (A.6) | collection | list · create · read · update · delete | upload · generate · link as a role's default |
+| **`jobs`** | `Job` + `Match` (A.8) | collection (query-heavy) | list (filtered) · read | set **user_state** (bookmark/apply/dismiss) · attach **applied_resume_id** · **scrape** a snippet · query by **role / combined** |
+| **`ingest`** | runtime over `Job.state` | process | trigger · observe | **live event stream** (user-facing bar) · **history log** (admin table) |
+| **`sources`** | provider config (A.8 `source`) | collection | list · update | enable/disable · reorder scrape priority |
+| **`models`** | LLM routing config | collection/config | read · update | per-stage model assignment · provider keys · token budget |
+| **`stats`** | aggregates over `Job`/`Match` | read-only | read | filter global vs per-role |
+| **`system`** | app-level ops | config + actions | read · update | maintenance: re-score · vacuum · export · purge |
+
+> Singletons (`candidate`, `preferences`) and config blobs (`models`, `system`) are read-then-patch
+> resources; the collections (`roles`, `resumes`, `jobs`, `sources`) are list/CRUD with the extra
+> domain actions noted. `stats` is pure read.
+
+---
+
+## 3. Per-resource detail
+
+### Config family
+
+**`candidate`** — singleton; the identity source of truth.
+Owns: contact, `country`, `current_location`, `current_role`, `education[]`, `anti_preferences[]`,
+`base_salary`, and the Tier-2 `defaults` (`seniority`, `preferred_industries`). Two cross-cutting
+roles make this resource load-bearing well beyond its own screen: `base_salary` is the **feed's
+comparison anchor** (A.10) and the **seed** for each new role's `target_salary` (A.4). The legacy
+**PDF-import** path (`web/profile.py:/profile/import-pdf`) is a real action to carry forward.
+*Skills* are a sub-collection (`candidate/skills`) because roles reference them by stable `id` (A.3) —
+they need their own add/edit/remove lifecycle, and deletion must reckon with roles that reference the skill.
+
+**`roles`** — collection; the multi-target core (genuinely new — no equivalent in the repo today).
+Each role owns its Tier-1 query fields, `target_salary`, the **binary `applicable_skills` ref set**,
+`default_resume_id`, and the **sparse `overrides`** map. Beyond CRUD it needs: **pause** (`active:false`
+— stops ingesting without deleting), **duplicate** (clone as a draft), and — important for the UI —
+a way to read a role's **effective values** (overrides resolved against candidate defaults, A.10.1).
+Switching the *active* role to re-scope the feed is a read concern handled via `jobs` query params (§4), not a write here.
+
+**`preferences`** — singleton; global search prefs (A.5). `locations[]` + single global `radius_km`,
+`work_arrangement`, `job_types`, `max_days_old`. These are **hard pull filters** (A.5) — editing them
+changes *what gets ingested at all*, so a write here has pipeline consequences (re-ingest / re-filter),
+not just a stored-preference change.
+
+### Content family
+
+**`resumes`** — collection; the "Resume Management" feature (A.6). CRUD plus **upload** and
+**generate** sources. A resume may be tailored to a role (`role_id`) and may be a role's linked
+default (`Role.default_resume_id`).
+
+**`jobs`** — collection; the feed, and the busiest resource. Reads are **query-driven**:
+filter by a single role, by **combined** (union of all active roles' matches, de-duped — A.10.3),
+by `user_state`, and by completeness (full vs **snippet**, the salary red-flag filter — A.10.4).
+Writes are **state transitions on a posting**, not edits to it: set `user_state`
+(bookmark / apply / dismiss), attach `applied_resume_id` on apply (A.7), and **scrape** a snippet
+(promote `state: snippet → scored`). Each returned job carries its `matches[]` and computed
+**salary delta** (§4). The Job `salary` shape must be **verified against the live ingest/scoring code**
+before the delta feature is built (A.8 — flagged, not assumed).
+
+### Runtime / Admin family
+
+**`ingest`** — the scraping process, exposed two ways that share one event vocabulary (`ui-layout.md`
+hybrid ingest log): a **live event stream** (the user-facing bottom bar — discovered/scored/deduped/error
+events as they happen) and a **searchable history log** (the admin analytics table). Trigger-and-observe,
+not request/response.
+
+**`sources`** — provider config (LinkedIn, Indeed, Greenhouse, Lever, HN, Wellfound …). List + update,
+with **enable/disable** and **reorder** (scrape priority — the live app's Sortable.js provider list).
+
+**`models`** — LLM routing: per-stage model assignment (scoring / extraction / dedup / resume-tailoring),
+provider keys, token budget. Config read/update.
+
+**`stats`** — read-only aggregates over jobs/matches (ingested / scored / high-match / applied / apply-rate
+/ avg-score), global or per-role.
+
+**`system`** — app-level schedule + storage facts and **maintenance actions**: re-score, vacuum, export,
+and the destructive purge/wipe operations (the "danger zone").
+
+---
+
+## 4. Cross-cutting derivations (where the model does real work)
+
+These are the computed behaviors (A.10) the API must serve. They're the reason "just CRUD the entities"
+isn't enough.
+
+- **Effective Tier-2 values.** `effective(role, field) = role.overrides[field] ?? candidate.defaults[field]`.
+  A role's *stored* shape is sparse; its *effective* shape needs the candidate merged in. **Decision point
+  in §6.1** — does the API resolve this (return effective values) or hand back raw rows for the client to merge?
+- **Effective skill set per role.** `candidate.primary_skills.filter(s ∈ role.applicable_skills)` (A.10.2).
+- **Combined view.** Not stored — a runtime union of every `active` role's matched jobs, de-duped by
+  `job.id`, each tagged with the role(s) that surfaced it (A.10.3). Best modeled as a **query mode on
+  `jobs`** (e.g. a `combined` scope), not a separate resource — §6.2.
+- **Salary delta vs base.** `(jobSalaryPoint − base_salary) / base_salary` → "+20% vs base" (A.10.4).
+  Needs currency/period normalization; ranges use the midpoint. **No-salary = red flag, not a filter** —
+  the job still returns, flagged. Where normalization happens is part of §6.1.
+- **Hard pull filters.** `work_arrangement` / `job_types` / `max_days_old` constrain ingestion *before*
+  scoring (A.5) — they belong to the `ingest` + `preferences` boundary, not to a post-hoc `jobs` filter.
+
+---
+
+## 5. UI screen → resource traceability
+
+So the endpoint design stays anchored to what the screens (`ui-layout.md`) actually call:
+
+| Screen | Primary resource(s) |
+|---|---|
+| Feed (per-role & Combined) | `jobs` (query: role / combined / state / completeness) |
+| Inspector (job detail + apply) | `jobs` (read + state/apply), `resumes` (pick) |
+| Candidate Profile | `candidate`, `candidate/skills` |
+| Roles editor | `roles` (+ reads `candidate/skills`, `resumes` for linking) |
+| Job Preferences | `preferences` |
+| Ingest bar (live) / Admin ingest log | `ingest` (stream / history) |
+| Admin → Job Sources | `sources` |
+| Admin → LLM & Models | `models` |
+| Admin → Stats | `stats` |
+| Admin → System | `system` |
+
+---
+
+## 6. Open API-design decisions (flag, don't invent)
+
+The model is locked; these are **API-shape** choices the model doesn't dictate. Each needs a call
+before path/payload design. (Listed with a lean where I have one — none are decided.)
+
+1. **Tier resolution: server-side vs client-side.** Recommend **server-side** — endpoints return
+   effective (resolved) values and computed deltas inline, so each client/screen doesn't re-implement
+   the inheritance + salary math. Raw-row alternative pushes that logic to every consumer. *Lean: server-side.*
+2. **Combined view: query mode vs dedicated resource.** Recommend a **scope/param on `jobs`**
+   (`combined` vs a single role) rather than a separate `/combined` resource — it's the same Job data,
+   merged differently. *Lean: query mode.*
+3. **Ingest contract: how `trigger → observe` is shaped.** Polling a task status vs a push/stream
+   (SSE/websocket) for the live bar. The live app already streams, which argues for push. *Lean: stream.*
+4. **Single-user singleton vs multi-user.** If multi-user is on the roadmap, `candidate` /
+   `preferences` stop being singletons and everything scopes under an account — cheaper to decide now
+   than to re-root later. *No lean — depends on product intent; worth your call.*
+5. **Snippet promotion: explicit action vs automatic.** Is "scrape this snippet" a user-triggered
+   action on a job, a background pass, or both? Affects whether `jobs` needs a write action or just reflects pipeline state.
+6. **Salary normalization home.** Currency/period normalization for the delta — done at ingestion
+   (stored normalized) or at read (computed per request)? Ties to decision #1.
+
+---
+
+*Companion docs: `docs/data-model.md` (normative entities — the source for every resource here),
+`docs/ui-layout.md` (screens these resources back), `docs/design-principles.md` (layout rules).
+Update this file if the data model or IA changes.*

--- a/docs/design/data-model.md
+++ b/docs/design/data-model.md
@@ -1,0 +1,496 @@
+# job-matcher — data model & schema (Candidate · Roles · Job Preferences)
+
+> **Purpose.** The canonical data model for the job-matcher redesign — every entity, field, and
+> relation in one place — plus the dated decision log that explains *how* the model got here.
+> UI work codes against **§A (normative model)**; the sections below it are the rationale and the
+> capture of the *current* codebase that the redesign extends.
+>
+> Renamed from `role-schema.md` → `data-model.md` (2026-05-29) once it outgrew its original
+> "role schema" scope: it now defines the whole three-category model (Candidate · Roles · Job
+> Preferences) plus the Skill, Resume, Application, and Job entities. `roles-editor-rebuild.md`
+> references are updated to point here.
+>
+> **Source of truth (read-only reference repo):** `I:\career\job-matcher`
+> Captured: 2026-05-29. The `file:line` anchors in §2 are real references into that repo. Entities
+> in §A are tagged **[captured]** (verified against the repo) or **[designed]** (new redesign work,
+> not yet in the repo) so provenance stays honest — per the project's "cite sources" discipline,
+> **no `file:line` anchor is invented** for `[designed]` entities; they carry a "verify at build" note.
+
+---
+
+## 0. Top-level information architecture — DECISION (2026-05-29)
+
+The model divides into **three top-level categories**. This is the organizing frame; the tier
+model (§3) describes *how fields behave* within and across these categories, but the categories
+are what the user sees and navigates. User's words: *"divide into three separate high level
+categories which goes beyond just the role schema."*
+
+| Category | Holds | Nature |
+|---|---|---|
+| **Candidate Profile** | Name, email, **current location**, **current role**, education, **skills** (the shared bucket), **base salary** | Who the candidate *is* — one source of truth |
+| **Roles** | Specific target roles, each with **target salary**, **selected skills** (visibility set), and **a matching resume** | What the candidate is *aiming for* — multiple, switchable |
+| **Job Preferences** | **Locations** (willing-to-work set), **Work Models** (onsite/hybrid/remote), **Job Types** (Contract / Contract-to-Hire / Full-Time / …) | *Where & how* the candidate will work — global, search-wide |
+
+### How this maps to the tier model (§3)
+
+- **Candidate Profile** ≈ **Tier 3 (shared-only)** + identity. Contains `primary_skills` (shared
+  bucket), `education`, `anti_preferences`, `country`, contact fields, plus three fields elevated
+  here: **current location**, **current role**, and **base salary** (see "New / moved fields" below).
+- **Roles** ≈ **Tier 1 (target-defined)** + per-role attributes. Each role owns `search.what`,
+  prefilter title gates, `scoring.threshold`, `scoring_notes`, its **selected-skills visibility set**,
+  its **target salary**, and its **linked resume**.
+- **Job Preferences** ≈ the **Global search-preferences layer** (§3). `locations[]`,
+  `work_arrangement`, `job_types` — not per-role, not overridable.
+
+### New / moved fields this introduces
+
+- **Current location** → Candidate Profile (identity). The candidate's home/base — and the
+  distance-scoring origin, *not* the first entry of the willing-to-work `locations[]`. The two are
+  cleanly separated: *current location* = where you are; *Locations* (Job Preferences) = where you'd
+  take a job.
+- **Current role** → Candidate Profile. A **new field** (e.g. "Senior Software Engineer") describing
+  what the candidate does *today* — distinct from the target **Roles** they're searching for.
+- **Base salary** → Candidate Profile. A **new field** — the candidate's current/reference total
+  compensation. It does **two jobs** (DECIDED 2026-05-29): (a) the **comparison anchor** for the
+  feed — a posting renders as e.g. *"+20% vs your base"*; and (b) the **seed** for a new role's
+  `target_salary` (then editable per role). User's words: *"this information should also be used to
+  help display comparisons in the actual job search, so you could visually see Job A is +20% your
+  base"* and *"[a candidate-level default salary should] seed a new role (editable per role)."*
+- **Target salary → per-role (Roles).** `salary_min` was Tier 2 (shared default w/ override); it is
+  now a **per-role attribute** (`role.target_salary`), seeded from `candidate.base_salary`.
+- **Resumes → under Roles.** Each role links a default "matching resume"; per-application resumes
+  are modeled by the **Application** entity (§A). Previously a standalone management surface.
+
+### Navigation impact (rail)
+
+The earlier plan was **Profile › Roles · Skills · Resumes**. This IA replaces that with **three
+top-level config destinations**:
+
+1. **Candidate Profile** (absorbs the standalone *Skills* surface — skills are part of the candidate)
+2. **Roles** (absorbs *Resumes* — each role links its matching resume)
+3. **Job Preferences** (new — the global locations / work-model / job-type surface)
+
+The rail's **Roles quick-switcher** (active-target selector for browsing the feed) is unaffected —
+that's a runtime view control, separate from these three config destinations.
+
+---
+
+## A. Canonical data model (NORMATIVE) — this is what UI codes against
+
+> Pseudo-schema, not a specific serialization. Types are indicative. `?` = optional/nullable.
+> Tags: **[captured]** = exists in the live repo today (anchors in §2); **[designed]** = new
+> redesign work (verify field-for-field against the repo when UI/persistence work begins).
+
+### A.1 Entity–relationship overview
+
+```
+                         ┌──────────────────────────────┐
+                         │  Candidate (singleton)        │
+                         │  identity · base_salary ·     │
+                         │  defaults · primary_skills[]  │
+                         └───────────────┬──────────────┘
+            owns bucket  │               │ owns                 owns (1)
+        ┌────────────────┘               │                        │
+        ▼                                ▼                         ▼
+   ┌─────────┐  applicable_skills   ┌─────────┐  default_resume  ┌──────────────────────┐
+   │ Skill   │◀───────(*..*)────────│ Role    │────(0..1)───────▶│ JobPreferences       │
+   │ id·name │   (binary refs)      │ target_ │                  │ (singleton, global)  │
+   │ ·years  │                      │ salary· │                  │ locations[]·         │
+   └─────────┘                      │ tier-1· │                  │ work_arrangement·    │
+                                     │ overrides│                 │ job_types            │
+                                     └────┬────┘                  └──────────┬───────────┘
+                                          │ tailored-for (0..1)              │ filters
+                                          ▼                                  │ ingestion
+   ┌──────────────┐                                          applied_resume_id  ┌──────────────────┐
+   │ Resume       │◀──────────────────(0..1)─────────────────────────────────────│ Job (posting)    │
+   │ id·label·    │   default_resume_id (from Role, above)                        │ salary·source·   │
+   │ role_id?     │                                                              │ matches[] (per   │
+   └──────────────┘   (Application join entity DEFERRED — A.7)                    │ role)·user_state │
+                                                                                  └──────────────────┘
+        candidate.base_salary ───────────(comparison anchor)──────────▶ Job.salary  (derived %)
+```
+
+### A.2 `Candidate` — singleton  **[captured + designed]**
+
+```
+Candidate {
+  // identity (Tier 3 — captured, except current_role/base_salary which are designed)
+  name:             str
+  email:            str
+  current_location: { label: str, lat?: num, lng?: num }   // home/base = distance origin
+  current_role:     str            // [designed] what they do today, e.g. "Senior SWE"
+  education:        Education[]     // [captured]
+  anti_preferences: str[]          // [captured]
+  country:          str            // [captured]
+
+  // shared skill bucket (Tier 3) — defined ONCE, referenced by roles
+  primary_skills:   Skill[]        // [captured-shape, simplified] see A.3
+
+  // compensation anchor (Tier 3) — [designed], DECIDED 2026-05-29
+  base_salary: {
+    amount:   num
+    currency: str           // e.g. "USD"
+    period:   "year" | "hour"
+  }
+  // base_salary = the candidate's CURRENT/REFERENCE comp (DECIDED 2026-05-29) — an anchor,
+  // NOT a desired floor. Roles A) seed target_salary from it; B) the feed shows each posting's
+  // delta vs it ("+20% vs base").
+
+  // shared Tier-2 defaults a role may override (sparse override on the role side)
+  defaults: {
+    seniority:            str       // [captured]
+    preferred_industries: str[]     // [captured]
+  }
+}
+
+Education { degree_type: str, degree_field: str, school: str, graduation_year: int }   // [captured]
+```
+
+### A.3 `Skill` — member of `Candidate.primary_skills`  **[captured-shape, simplified 2026-05-29]**
+
+```
+Skill {
+  id:    str     // [designed] STABLE id — required so roles can reference it; text key too fragile
+  name:  str     // was `description`
+  years: int     // was `years_active`
+}
+// `active` boolean from the legacy shape is DROPPED. No per-skill weight anywhere.
+```
+
+Referenced by `Role.applicable_skills` (binary on/off, see A.4).
+
+### A.4 `Role` — one per target (SWE, Data Engineer, Platform, …)  **[designed]**
+
+```
+Role {
+  id:     str
+  name:   str
+  color:  str            // identity color used across the shell
+  active: bool           // false = paused (stops ingesting; not deleted)
+
+  // ── Tier 1 — target-defined (no shared base) ──
+  search_what:   str               // the core query — this *is* the role
+  prefilter: {
+    title_include: str[]
+    title_exclude: str[]
+  }
+  threshold:     num               // 0–10, min score to surface
+  scoring_notes: str[]             // prose to the LLM — where "weigh Spark higher" lives
+
+  // ── per-role attributes ──
+  target_salary:     num           // seeded from candidate.base_salary, then editable
+  applicable_skills: str[]         // BINARY refs into candidate.primary_skills[].id
+  default_resume_id: str?          // the role's linked "matching resume" (→ Resume.id)
+
+  // ── Tier 2 — shared default w/ override (SPARSE: present key = override; absent = inherit) ──
+  overrides: {
+    seniority?:            str
+    preferred_industries?: str[]
+  }
+}
+```
+
+`location` / `distance` / `work_arrangement` / `job_types` are deliberately **absent** — they are
+global (A.5), not per-role.
+
+### A.5 `JobPreferences` — singleton, global  **[designed]**
+
+```
+JobPreferences {
+  locations: Location[]                       // multiple willing-to-work places
+  radius_km: num                              // SINGLE global radius applied to every location (DECIDED 2026-05-29)
+  work_arrangement: ("onsite"|"hybrid"|"remote")[]    // multi-select HARD PULL FILTER
+  job_types: ("contract"|"contract_to_hire"|"full_time"|"part_time"|"internship")[]   // multi-select HARD PULL FILTER
+  max_days_old: int?                          // [captured legacy `search.max_days_old`] global freshness gate (DECIDED 2026-05-29: global)
+}
+
+Location { label: str, lat?: num, lng?: num }  // NO per-location radius — radius is global (above)
+```
+
+These apply to **every** role's search equally and **cannot be overridden** by a role.
+`work_arrangement` and `job_types` are **hard pull filters** (DECIDED 2026-05-29) — they exclude
+non-matching postings *at ingestion / before LLM scoring*, mapping to legacy `require_contract_time`
+/ `require_contract_type`. Not soft scorer signals.
+
+### A.6 `Resume`  **[designed]** — new "Resume Management" functionality
+
+```
+Resume {
+  id:          str
+  label:       str            // e.g. "SWE — backend focus v3"
+  role_id:     str?           // tailored for which Role (null = generic / base resume)
+  source:      "uploaded" | "generated" | "edited"
+  content_ref: str            // pointer to stored file/blob
+  created:     datetime
+  updated:     datetime
+}
+```
+
+A `Role.default_resume_id` points to the resume attached by default when applying under that role.
+The specific resume *used for a given application* lives on the **Application** (A.7), so one role
+can still send different resumes to different postings.
+
+### A.7 Per-application resume — LINK ONLY, for now  **[designed]** (DECIDED 2026-05-29)
+
+**Decision:** do **not** build a full `Application` join entity yet. Model the per-application resume
+as a simple **`applied_resume_id` reference on the Job** (alongside its existing applied state). User's
+words: *"For now link to a resume id."*
+
+```
+// On Job (A.8): when user_state === "applied"
+applied_resume_id: str?     // → Resume.id — the resume used for THIS posting (null = none chosen)
+```
+
+This satisfies *"create and store per-job-application resumes"* at the lightest weight: a job pursued
+under a role can carry the specific resume it was sent with, without a separate entity. A richer
+`Application` record (status pipeline: interviewing / rejected / offer / withdrawn, applied_at, notes)
+is the **natural upgrade** when application *tracking* becomes a feature — captured here as the
+deferred path, not built now.
+
+```
+// DEFERRED — promote to this when application tracking is scoped:
+Application { id, job_id, role_id, resume_id, status, applied_at, notes }
+```
+
+### A.8 `Job` — a scraped posting (a "snippet" before it's scored)  **[captured-shape]**
+
+```
+Job {
+  id:            str
+  title:         str
+  company:       str
+  location:      { label: str }
+  remote_type:   "onsite" | "hybrid" | "remote" | null
+  contract_type: str | null
+  salary:        { min?: num, max?: num, currency: str, period: "year"|"hour" } | null
+  source:        str          // LinkedIn, Indeed, Greenhouse, Lever, HN, Wellfound, …
+  posted_at:     datetime
+  ingested_at:   datetime
+  state:         "snippet" | "scored"   // snippet = discovered, not yet LLM-scored
+
+  // per-role scoring — a job can match multiple roles (drives Combined view)
+  matches: Match[]
+
+  user_state:    "new" | "bookmarked" | "applied" | "dismissed"
+  applied_resume_id: str?     // → Resume.id, set when applied (per-application resume, A.7)
+}
+
+Match {                       // [captured: score/skills/verdict are the live card's data]
+  role_id:        str
+  score:          num         // 0–10, tier: hi 8+, mid 5–7, lo <5
+  matched_skills: str[]       // skill ids (or names) present in the posting
+  missing_skills: str[]
+  verdict:        str
+  overridden_via: str[]       // which Tier-2 overrides applied — combined-view marker (§6 rebuild)
+}
+```
+
+Job field shapes should be **verified against the live ingest/scoring code** when persistence work
+begins — the card UI confirms `score / matched / missing / verdict / source / snippet-state`, but
+the exact `salary` shape (needed for the comparison feature) must be checked, not assumed.
+
+### A.9 Relations (summary)
+
+| From | → To | Cardinality | Mechanism |
+|---|---|---|---|
+| Candidate | Skill | 1 → * | owns `primary_skills[]` |
+| Role | Skill | * ↔ * | `applicable_skills[]` (binary id refs) |
+| Candidate | Role | 1 → * | owns roles |
+| Candidate | Resume | 1 → * | owns resumes |
+| Resume | Role | * → 0..1 | `role_id` (tailored-for) |
+| Role | Resume | 1 → 0..1 | `default_resume_id` (linked default) |
+| Job | Resume | * → 0..1 | `applied_resume_id` (resume used for this application — A.7 link-only) |
+| ~~Application~~ | ~~Job / Role / Resume~~ | *deferred* | join entity not built yet (A.7) |
+| Job | Match | 1 → * | per-role scoring |
+| JobPreferences | Job | 1 → * | global filter on ingestion |
+| Candidate.base_salary | Job.salary | derived | comparison % (A.10) |
+
+### A.10 Derived / computed values (not stored)
+
+1. **Effective Tier-2 value:** `effective(role, field) = role.overrides[field] ?? candidate.defaults[field]`.
+2. **Effective skill set for a role:** `candidate.primary_skills.filter(s => role.applicable_skills.includes(s.id))`.
+3. **Combined view:** union of every `active` role's matched Jobs, de-duped by `job.id`, each tagged
+   with the role(s) whose `Match` surfaced it; overridden matches carry the `overridden_via` marker.
+4. **Salary delta vs base (NEW):**
+   `delta = (jobSalaryPoint − candidate.base_salary.amount) / candidate.base_salary.amount`,
+   rendered as e.g. `+20% vs base`. Requires currency/period normalization; ranges use the midpoint.
+   Anchor = `candidate.base_salary`; an optional secondary comparison vs `role.target_salary` is
+   possible but not the default.
+   **No-salary postings (DECIDED 2026-05-29): a missing/unextracted salary is a "RED FLAG," NOT a
+   hard filter.** The posting still surfaces in the feed, visibly flagged (e.g. a red "no salary"
+   marker in place of the delta) rather than dropped. The UI **may offer an opt-in filter** to hide
+   jobs without an extracted salary, but that is a user-toggled view filter — never automatic
+   exclusion at ingestion.
+
+---
+
+## 1. The structural reality today
+
+- **There is exactly one profile.** No "target" or "role" concept exists yet — multi-target is
+  genuinely new work, not a refactor of an existing list.
+- **A profile's definition is split across two files**, and the `/profile` form fuses them in the UI:
+
+  | File | Owns | Nature |
+  |---|---|---|
+  | `config/profile.json` | Who the candidate *is* (skills, education, seniority, location) | Candidate identity |
+  | `config/config.json` | What jobs to *find & score* (search, prefilter, threshold) | Search / match criteria |
+
+- The `/profile` form (`web/profile.py`) deep-merges only the **candidate-facing subset** of
+  `config.json` and leaves technical keys (`results_per_page`, `max_pages`, etc.) untouched.
+- A **PDF resume import** path (`/profile/import-pdf`) LLM-extracts `primary_skills`, `education`,
+  `seniority`, `preferred_industries`, and `location_center` to pre-fill the form.
+
+---
+
+## 2. Full field inventory (current codebase — [captured])
+
+### From `profile.json` — candidate identity  (anchor: `web/profile.py:163-177`)
+
+| Field | Shape | Notes |
+|---|---|---|
+| `primary_skills` | `[{description, years_active:int, active:bool}]` | 3-column skills table — **not** flat strings. `active` = currently using it. *(Redesign simplifies → `{id, name, years}`; see A.3.)* |
+| `anti_preferences` | `[str]` | Things to avoid (repeating rows). |
+| `education` | `[{degree_type, degree_field, school, graduation_year}]` | Structured; legacy free-text auto-migrated on load. |
+| `seniority` | `str` | Free text / select. |
+| `preferred_industries` | `[str]` | Repeating rows. |
+| `location` | `{center, radius_km:float, geocode_fallback, notes}` | `geocode_fallback` defaults to `"pass"`. *(Redesign splits → current_location (identity) + global locations[].)* |
+| `scoring_notes` | `[str]` | Free-form instructions fed to the LLM scorer. |
+
+### From `config.json` — candidate-facing subset  (anchors: `config.example.json`, `web/profile.py:179-289`)
+
+| Block | Fields | Notes |
+|---|---|---|
+| `search` | `country, what, where, distance (km), salary_min, max_days_old` | `what` / `where` are the core query. Technical keys `results_per_page`, `max_pages` are left untouched by the form. |
+| `scoring` | `threshold` (0–10) | Minimum score to appear in the feed. |
+| `prefilter` | `title_include[], title_exclude[], require_contract_time, require_contract_type` | Case-insensitive title substring gates applied *before* LLM scoring to save cost. |
+
+---
+
+## 3. The multi-target model — DECISION (2026-05-29)
+
+**Tier model: shared core with per-role override, plus inherently per-role fields.**
+Confirmed by user: *"a split, with the Core items being shared with the option of an override."*
+
+Three role tiers, **plus a global layer that sits outside the role model entirely.** The global
+search preferences below are not per-role and **cannot be overridden by a role** — they apply to
+every role's search equally.
+
+### Global search preferences (outside the role tiers; not per-role, not overridable) — DECIDED 2026-05-29
+
+User's words: *"Location and Job Type should be two more fields that are completely separate from
+the Roles. They are search preference parameters that should be configurable but not linked to
+specific Roles."* These describe **where** and **how** the candidate is willing to work — true of
+the person's job search as a whole, not of any one target. Normative shape: see **A.5**.
+
+- **`locations[]` — multiple acceptable locations.** Replaces the legacy single `location.center` +
+  `radius_km`. (e.g. *"fine moving to California or Seattle, or staying where I am"*.)
+- **`work_arrangement` — multi-select over {onsite, hybrid, remote}.**
+- **`job_types` — multi-select over {Contract, Contract-to-Hire, Full-Time, …}.** Maps to the legacy
+  prefilter `require_contract_time` / `require_contract_type`, lifted to a global preference.
+
+**This supersedes two earlier placements** (both moved here, both no longer per-role):
+- `location` (center/notes) and `search.distance` / `location.radius_km` were **Tier 2** — now global,
+  **not role-overridable**. The earlier "a remote-only role may override location" rationale is
+  replaced by the global `work_arrangement` toggle.
+- `require_contract_time` / `require_contract_type` were implied per-role prefilter gates — now global.
+
+### Tier 1 — Target-defined (always per-role; no shared base)
+- `search.what` — the core query; this *is* the role.
+- `prefilter.title_include[]` / `title_exclude[]` — role-specific title gates.
+- `scoring.threshold` — each role can demand a different match bar.
+- `scoring_notes[]` — role-specific scoring guidance to the LLM.
+
+### Tier 2 — Shared with override (candidate default, role may override)
+Defaults live on the shared candidate base; a role can override the value for itself. The UI shows
+the inherited value with an explicit "override for this role" affordance + a way to revert.
+
+- `seniority`
+- `preferred_industries[]`
+- *Skill applicability (per-role visibility set)* — **DECIDED 2026-05-29.** The candidate's
+  `primary_skills` are a single shared bucket (Tier 3). Each role carries a **visibility set**: refs
+  to shared skill IDs "turned on" for that role. Defined once, reused — never duplicated — each role
+  exposes only its tailored subset (SWE → {X, Z}; Data → {Y, Z}). Per-role membership is **binary**
+  (`applicable: true|false`); **no per-role numeric weighting** — emphasis goes through `scoring_notes`
+  prose. User's words: *"shared bucket where you turn on the visibility of a skill to a role type…"*
+  and *"No weighting per role… instruct the LLM to weigh relevant skills higher."*
+
+> **Moved out of Tier 2 (do not treat as overridable):**
+> - ~~`salary_min`~~ → **per-role `target_salary`** (Roles), seeded from `candidate.base_salary` (§0, A.4).
+> - ~~`search.distance` / `location.radius_km`~~ and ~~`location` (center/notes)~~ → **Global** (A.5).
+
+### Tier 3 — Shared only (candidate identity; never per-role)
+- `primary_skills[]` — simplified to **`{id, name, years}`** (A.3); `active` dropped.
+- `education[]`
+- `anti_preferences[]`
+- `country`
+- **`base_salary`** (new — comparison anchor + role-salary seed, §0/A.2)
+- Contact / identity fields (incl. **current_location**, **current_role**)
+
+---
+
+## 4. Gaps in the current prototype Roles screen (to fix when UI work resumes)
+
+The prototype's Roles editor invented a thin field set and **missed or misrepresented** real schema:
+
+- **Missing:** `anti_preferences`, `education`, `scoring_notes`, prefilter `title_include`/`title_exclude`,
+  `seniority`, `preferred_industries`.
+- **Misrepresented skills:** the editor duplicates a skill set *into* each role with invented
+  must-have/weighted/nice-to-have tiers. Real model = **one shared `primary_skills` bucket**
+  (`{id, name, years}`), each role holding only a **binary visibility set** of references (A.4). The
+  editor must **select-from-shared**, not re-author skills per role.
+- **Ignores the tier model:** treats every field as flatly per-role; no shared-default/override
+  distinction.
+- **Wrongly per-role: location.** `locations[]`, `work_arrangement`, `job_types` are **global**
+  (Job Preferences surface), not role fields.
+- **Salary unmodeled correctly:** the prototype's per-role salary is fine *as a per-role field*, but
+  it must be **seeded from `candidate.base_salary`** and the feed must show the **delta-vs-base**
+  comparison (A.10) — neither exists yet.
+- **No Resume / Application model:** the linked "matching resume" (`Role.default_resume_id`) and
+  per-application resumes (`Application`) aren't represented anywhere in the prototype.
+
+---
+
+## 5. Resolved decisions + open items
+
+### Resolved (2026-05-29)
+
+- **Three top-level categories** — Candidate Profile · Roles · Job Preferences (§0). Skills fold into
+  Candidate Profile; Resumes fold into Roles; Job Preferences is the global search-prefs surface.
+- **Skill model** — one shared bucket `{id, name, years}` (Tier 3); roles hold a **binary visibility
+  set** of references; no per-role weighting (emphasis via `scoring_notes`). Stable skill `id` required.
+- **Location & Job/Contract Type — global, not per-role.** `locations[]`, `work_arrangement`, `job_types`.
+- **Target salary — per-role**, seeded from `candidate.base_salary`.
+- **Base salary — Candidate Profile field, dual-purpose (NEW 2026-05-29):** comparison anchor for the
+  feed (*"+20% vs base"*) **and** the seed for new-role `target_salary`. Resolves the prior
+  "shared salary default?" open refinement — **yes, it seeds; editable per role.**
+- **Resumes & Applications modeled (NEW 2026-05-29):** `Resume` (A.6) with a per-role `default_resume_id`
+  link, and `Application` (A.7) joining Job + Role + Resume + status — the home for *per-application
+  resumes*.
+- **Override UX — inline**; **Manage-skills surface — dedicated** (now under Candidate Profile);
+  **Combined-view override labeling — yes, clutter-gated.** (See `roles-editor-rebuild.md §6`.)
+
+### The "rock solid" checklist — ALL LOCKED (2026-05-29)
+
+The six open items below are now decided. **No open model questions remain — the schema is locked
+for UI work.**
+
+1. ✅ **`base_salary` semantics → CURRENT/REFERENCE comp** (the comparison anchor), not a desired
+   floor. (A.2)
+2. ✅ **Radius → SINGLE global radius** applied to every location. No per-location radius;
+   `Location` is just `{label, lat?, lng?}`. (A.5)
+3. ✅ **Per-application resume → LINK ONLY for now** — an `applied_resume_id` reference on the Job,
+   *not* a full `Application` join entity. The join entity is the documented deferred upgrade for
+   when application *tracking* is scoped. (A.7/A.8)
+4. ✅ **`work_arrangement` / `job_types` → HARD PULL FILTERS** — exclude non-matching postings at
+   ingestion / before LLM scoring. Not soft scorer signals. (A.5)
+5. ✅ **Job `salary` — no-salary is a RED FLAG, not a hard filter.** Postings without an extracted
+   salary still surface, visibly flagged; the UI may offer an opt-in filter to hide them. Range
+   postings use the midpoint. *(Live posting `salary` shape should still be verified against the repo
+   at the moment delta-vs-base persistence is built — A.8/A.10.)*
+6. ✅ **`max_days_old` → Job Preferences (global).** (A.5)
+
+---
+
+*Update this file as the model evolves. §A is normative (UI codes against it); §1–§3 capture the
+real repo with `file:line` anchors; keep both honest. Companion: `roles-editor-rebuild.md`
+(build plan), `design-principles.md` (layout rules).*

--- a/docs/design/design-principles.md
+++ b/docs/design/design-principles.md
@@ -1,0 +1,53 @@
+# Design principles — job-matcher redesign
+
+> **Purpose.** Standing layout/visual rules for the job-matcher redesign, so every screen
+> tailored from here on stays consistent. Applied across the active Shell B prototype
+> (`job-matcher-shell-b-2.html`) and any screens that follow.
+>
+> Established: 2026-05-29. Keep updated as new principles are locked in.
+
+---
+
+## 1. Alignment by width behavior  (LOCKED 2026-05-29)
+
+The governing rule, stated by the user:
+
+> - **If an element has expanding width → left-aligned.**
+> - **If an element has fixed width → center-aligned.**
+
+The intent is to **eliminate wasted space**. The failure mode this fixes: expanding content
+(fluid grids, `1fr` columns, `auto-fill` tiles) that was capped to a narrow `max-width` and
+pinned left, leaving a dead band of empty canvas on the right.
+
+### How to apply
+
+| Element nature | Behavior | Rule |
+|---|---|---|
+| **Expanding** — fluid grids, tables, `1fr` form columns, `auto-fill` tile rows, feed lists | Fill the available content width | Left-aligned, no `max-width` cap. Let it stretch. |
+| **Fixed** — a card/modal/control with an intrinsic or deliberately bounded width | Sits centered in its container | Center-aligned (e.g. `margin-inline: auto`). |
+
+### Exceptions (NOT wasted space — leave capped)
+
+- **Prose reading-measures.** Description/explainer paragraphs keep a `~60ch` / `62ch`
+  `max-width` for line-length legibility. This is typographic control, not a layout cap.
+- **Inline fixed-width controls inside a left-aligned form.** A genuinely fixed control
+  (e.g. the ~340px skill-add input) stays at its width and stays put within its left-aligned
+  parent — it does not get centered in isolation.
+
+### Applied so far
+
+Removed page-level width caps (`880 / 920 / 1040px`) that were pinning expanding content:
+Roles workspace, Admin → Stats KPI tiles, Admin tables (Sources, Models, Ingest log) and their
+toolbars, Profile cards / account banner / add buttons. All now fill the content column.
+
+### Open watch item
+
+On ultra-wide displays (≥1920px) the Roles **editor** two-column form gets very wide
+(~700px/field). The editor is form content with a natural max width — it is the one place
+that may warrant the *fixed → centered* branch (cap-and-center) rather than full-bleed.
+Not yet applied; revisit if it reads too loose.
+
+---
+
+*Update this file as principles are added or refined. It is the standing rulebook for
+per-screen tailoring — anchor new screen work to it.*

--- a/docs/design/roles-editor-rebuild.md
+++ b/docs/design/roles-editor-rebuild.md
@@ -1,0 +1,178 @@
+# Roles editor — rebuild scope
+
+> **Purpose.** Scope (not yet build) the rebuild of the **Profile › Roles** editor in
+> `job-matcher-shell-b-2.html` so it reflects the *real* schema and the locked tier/skill model.
+> Anchored to `docs/data-model.md` (data model) and `docs/design-principles.md` (layout rules).
+>
+> Scoped: 2026-05-29. Status: **awaiting go-ahead before any UI change.**
+
+---
+
+## 1. Why rebuild (not patch)
+
+The current Roles editor invented its own field set and skill model. Per `data-model.md §4`, it:
+
+- **Misses** real fields: `anti_preferences`, `education`, `scoring_notes`, prefilter
+  `title_include` / `title_exclude`, `seniority`, `preferred_industries`.
+- **Misrepresents skills** — it duplicates a skill set into each role with invented
+  must-have / weighted / nice-to-have tiers. The real model is one **shared bucket** + a per-role
+  **binary applicable** flag.
+- **Ignores the tier model** — it treats every field as flatly per-role, with no shared-default /
+  override distinction.
+
+These are structural, not cosmetic — the data model the editor edits is wrong. A rebuild is cleaner
+than retrofitting override semantics and a shared-bucket skill control onto the invented structure.
+
+---
+
+## 2. The data model the editor must edit
+
+Two objects, per `data-model.md §3`:
+
+### Shared candidate base (one, global)
+```
+candidate = {
+  primary_skills: [ { id, name, years } ],   // ← shared bucket; {id,name,years} only
+  education:        [ { degree_type, degree_field, school, graduation_year } ],
+  anti_preferences: [ str ],
+  country:          str,
+  current_location: { label, lat?, lng? },   // home/base = distance origin
+  current_role:     str,                     // what they do today (≠ target roles)
+  base_salary:      { amount, currency, period },  // comparison anchor + seeds role target_salary
+  defaults:         { seniority, preferred_industries },  // Tier-2 shared defaults
+  // identity/contact…
+}
+```
+Full normative shape (incl. Resume / Application / Job entities and relations): `data-model.md §A`.
+
+### Role (one per target: SWE, Data Engineer, Platform, …)
+```
+role = {
+  id, name, color, active,        // active=false → paused (stops ingesting, not deleted)
+
+  // Tier 1 — target-defined (no shared base)
+  search_what:     str,           // the core query — this *is* the role
+  title_include:   [ str ],
+  title_exclude:   [ str ],
+  threshold:       0–10,
+  scoring_notes:   [ str ],       // ← where "weigh skill X higher" lives (prose to LLM)
+
+  // per-role attributes
+  target_salary:     num,         // seeded from candidate.base_salary, then editable
+  applicable_skills: [ skillId ], // BINARY refs into the shared bucket; no per-role weight
+  default_resume_id: str?,        // the role's linked "matching resume"
+
+  // Tier 2 — shared default, role may override (SPARSE: present key = override)
+  overrides: { seniority?, preferred_industries? }
+}
+```
+
+**Tier-2 is now just `seniority` + `preferred_industries`.** `salary` is a per-role attribute
+(`target_salary`, seeded from `candidate.base_salary`); `location` / `distance` / `work_arrangement`
+/ `job_types` moved **out of the role entirely** to the global **Job Preferences** surface — they are
+NOT in this editor. See `data-model.md §A.4` (normative Role) and `§A.5` (Job Preferences).
+
+**Locked skill decisions (2026-05-29):** global skill = `{id, name, years}` only (`active` dropped);
+role↔skill is **binary** `applicable`; **no per-role numeric weighting** — emphasis goes through
+`scoring_notes` prose.
+
+---
+
+## 3. Screen layout
+
+Keep the **master–detail** shape (it works), but correct the detail pane to the real model.
+Apply `design-principles.md`: the editor is expanding form content → **left-aligned, fills the
+column** (the ultra-wide cap-and-center watch item from that doc may apply to the detail form only;
+flag at build, don't pre-decide).
+
+```
+┌ Roles ─────────────────────────────────────────────────────────────────────┐
+│ ┌── role list ──┐ ┌── role editor (selected) ───────────────────────────┐  │
+│ │ ● SWE      12 │ │  [SWE ▸ editable title]            [⏸ pause] [Save]  │  │
+│ │ ● Data      9 │ │                                                       │  │
+│ │ ● Platform  7 │ │  TARGET-DEFINED (this role only)                      │  │
+│ │ ⊕ New role    │ │   • Search query (what)                               │  │
+│ └───────────────┘ │   • Title include / exclude gates                     │  │
+│                    │   • Match threshold (0–10)                            │  │
+│                    │   • Scoring notes  ← "weigh K8s higher", etc.         │  │
+│                    │   • Target salary  ← seeded from candidate base       │  │
+│                    │   • Linked resume  ← default_resume_id                │  │
+│                    │                                                       │  │
+│                    │  SHARED — OVERRIDABLE (inherits candidate default)    │  │
+│                    │   • Seniority / Preferred industries                  │  │
+│                    │     — each w/ inline override toggle                  │  │
+│                    │   (location/distance/work-model/job-type are GLOBAL,  │  │
+│                    │    not here → Job Preferences surface)                │  │
+│                    │                                                       │  │
+│                    │  SKILLS APPLICABLE (from shared bucket, on/off)       │  │
+│                    │   [✓ Python] [✓ AWS] [ ] Spark [✓ SQL] [ ] Airflow…   │  │
+│                    │   + manage shared skills →                            │  │
+│                    └───────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+Three labeled bands in the detail pane, matching the tiers — this makes the shared-vs-per-role
+distinction legible instead of implicit.
+
+---
+
+## 4. The two novel controls
+
+1. **Shared-skills applicability.** The role shows the *whole shared bucket* as toggle chips; checked
+   = `applicable` for this role. Toggling never edits the skill itself. A "manage shared skills" link
+   opens the one place skills are authored (add/rename/set years) — likely a small section or modal
+   that writes the candidate bucket, so every role sees the change. The chip's label shows
+   `name · {years}y`; no weight UI.
+
+2. **Override affordance (Tier 2).** Each shared-default field renders its inherited value with an
+   "override for this role" toggle. Overridden → field becomes editable + shows a "revert to shared"
+   action. Un-overridden → read-only, visibly inherited. (Inline pattern — locked in §6.)
+
+---
+
+## 5. Build phases (when greenlit)
+
+1. **Data layer** — replace the invented role objects with the §2 shape; give shared skills stable
+   `id`s; seed SWE/Data/Platform with realistic per-tier values.
+2. **Detail pane bands** — render the three tier bands; wire target-defined fields first (they're the
+   simplest, no inheritance).
+3. **Shared-skills control** — bucket chips + applicable toggles + "manage shared skills".
+4. **Override mechanics** — inherited display, override toggle, revert.
+5. **List + lifecycle** — role list counts, pause, new/duplicate drafts, Save.
+6. **Self-check** — checklist + 5-dim critique; confirm dark-ledger tokens, density, alignment rules,
+   `data-od-id`, localStorage target persistence all intact.
+
+Single-file SPA stays (live switching + shell recolor depend on it).
+
+---
+
+## 6. UX decisions (resolved 2026-05-29)
+
+- **Override UX — INLINE.** Each Tier-2 field renders its inherited value in place with an
+  "override for this role" toggle; overriding makes that one field editable + shows "revert to
+  shared". No separate overrides sub-section. Keeps each field's context next to its control.
+- **Manage-shared-skills surface — DEDICATED, now under Candidate Profile.** Skills are authored on
+  their own surface, not a modal buried in one role's editor. The role editor's applicability chips
+  link out to it. Rationale: it edits candidate-global data, so it deserves a first-class surface —
+  and every role reads from the same bucket, so it shouldn't feel owned by one.
+  - *Updated by the three-category IA (`data-model.md §0`, 2026-05-29):* the rail is now **three
+    top-level config destinations — Candidate Profile · Roles · Job Preferences** (not the earlier
+    "Profile › Roles · Skills · Resumes"). **Skills live inside Candidate Profile** (skills are part
+    of the candidate); **Resumes live inside Roles** (each role links its matching resume). So the
+    "manage shared skills" chip links into **Candidate Profile › Skills**, and the global
+    location/work-model/job-type fields live on the new **Job Preferences** destination — neither is
+    in the Roles editor.
+- **Combined view labeling — YES, but clutter-gated.** When a job matched under a role's *overridden*
+  Tier-2 value, the combined feed should surface it — but quietly. Decision: **a subtle marker, not a
+  verbose string.** Default to a small superscript/dot or an "override" micro-pill on the role color
+  flag, with the detail ("matched via SWE · salary floor overridden") deferred to the inspector on
+  click. If even the micro-marker reads busy in the dense feed, fall back to inspector-only. Build it,
+  judge clutter against the live feed at self-check, and dial back if it competes with the score tiers.
+
+*All three open questions from the prior scope are now settled. No open model questions remain for
+the Roles editor — the rebuild is unblocked.*
+
+---
+
+*Update alongside `data-model.md` if the model shifts. This is the build plan for the Roles screen;
+anchor the implementation to it once the user greenlights.*

--- a/docs/design/ui-layout.md
+++ b/docs/design/ui-layout.md
@@ -1,0 +1,261 @@
+# job-matcher — UI layout (high-level handoff)
+
+> **Purpose.** A self-contained description of the redesigned job-matcher UI's high-level
+> layout — the app shell, navigation, every screen, and the cross-cutting surfaces — written
+> so another agent can build or reason about it without re-deriving decisions from the chat
+> history. This is the **layout** companion to two other locked docs:
+>
+> - `docs/data-model.md` — the canonical entity/field model (Candidate · Roles · Job Preferences).
+> - `docs/design-principles.md` — the alignment/visual rules every screen follows.
+>
+> Read those two for *what the data is* and *how things align*. This doc is *where things live
+> on screen and how the user moves between them*.
+>
+> **Status (2026-05-29).** The locked shell is **"Shell B — sidebar rail + main + right inspector,"**
+> chosen by the user because the persistent left rail frees horizontal room for a right inspector
+> panel (the natural information-density expansion point). The working prototype is
+> `job-matcher-shell-b-2.html`. Where the built prototype diverges from the locked target IA, this
+> doc describes the **target** and flags the divergence in a callout.
+
+---
+
+## 1. Visual system (carried from the live app — non-negotiable)
+
+The redesign keeps the existing app's **dark "industrial terminal-ledger"** DNA verbatim. Do not
+introduce a new palette or type system.
+
+| Token | Value | Role |
+|---|---|---|
+| `--bg-base` | `#0f1117` | App ground |
+| `--bg-surface` | `#171b23` | Cards, rail, context bar |
+| `--bg-raised` | `#1e2330` | Inputs, raised controls |
+| `--text-primary` | `#eceef5` | Primary text |
+| `--text-muted` | `#7a8599` | Metadata, labels |
+| `--accent` | `#f5a623` | The one amber accent |
+
+**Semantic score tiers** (load-bearing — drive card flags, scores, skill chips):
+high `#4df590` (8+) · mid `#ffd24d` (5–7) · low `#ff6b6b` (<5).
+
+**Per-target identity colors** (new): SWE `#f5a623` · Data `#4dd2f5` · Platform `#b58cf5`.
+The active target's color is bound to `--target` and the **whole shell recolors** when the user
+switches role.
+
+**Type:** serif body (Georgia), mono for metadata/labels/numerics (Menlo/Consolas), system sans
+for titles/buttons. **Density is non-negotiable** — this is a dense operator tool, not editorial.
+
+---
+
+## 2. The app shell — three regions
+
+A single-file SPA. The shell is a CSS grid with three columns; the inspector column animates open
+from 0 width.
+
+```
+┌───────────┬───────────────────────────────────────────┬──────────────────┐
+│           │  CONTEXT BAR  (view-aware header)           │                  │
+│           ├───────────────────────────────────────────┤                  │
+│   RAIL    │  SUBBAR  (feed-only filters)                │   INSPECTOR      │
+│ (sidebar) ├───────────────────────────────────────────┤  (slides in on   │
+│           │                                             │   job click;     │
+│  nav +    │           MAIN CONTENT                      │   right side)    │
+│  role     │   (feed list OR a full-screen view)         │                  │
+│  switcher │                                             │                  │
+│           │                                             │                  │
+│           │                          [ ⟳ Ingest FAB ]   │                  │
+└───────────┴───────────────────────────────────────────┴──────────────────┘
+   236px              fluid (fills)                            360px (open)
+                ┌─────────── INGEST STREAM BAR (slides up from bottom) ──────────┐
+                └────────────────────────────────────────────────────────────────┘
+```
+
+- **Rail** (`236px`, fixed) — persistent navigation + the role quick-switcher. §3.
+- **Main** (fluid, fills) — a stack of: context bar → subbar → the active view. §4–§5.
+- **Inspector** (`360px`, toggled) — job detail / drill-down. Closed by default; `Esc` closes. §6.
+- **Ingest FAB + stream bar** — live scrape ticker, feed/role views only. §6.
+
+---
+
+## 3. The rail (left) — navigation + role switching
+
+The rail has two distinct jobs that must not be confused: a **runtime role switcher** (which
+target's results am I browsing?) and the **config destinations** (where I set things up).
+
+### 3.1 Target / role quick-switcher  *(runtime view control — top of rail)*
+
+A group listing each target role with its identity dot + name + match count, then a **Combined
+view** entry, then **Manage targets…**. Clicking a target:
+
+- switches the feed to that role's results,
+- rebinds `--target` so the shell recolors,
+- persists the choice to `localStorage` (`jm_target`).
+
+**Combined view** merges every active role's results, de-dupes by posting, and tags each row with
+a per-target color flag showing which role(s) matched it.
+
+This switcher is **separate** from the config destinations below — it is not "a page," it's the
+lens on the feed.
+
+### 3.2 Config & browse destinations
+
+> **⚠ Build-vs-target divergence.** The locked IA (`data-model.md §0`) is **three top-level config
+> destinations**. The current prototype rail still shows the older grouping (`Profile › Roles ·
+> Resumes` + a separate `Admin` group). **Target structure the receiving agent should build toward:**
+
+| Rail group | Destinations | Maps to |
+|---|---|---|
+| **Browse** | Feed · Bookmarks · Applied · Dismissed | runtime job lists (all feed-mode) |
+| **Candidate Profile** | identity · education · **Skills** (shared bucket) · base salary | `data-model.md` Candidate |
+| **Roles** | manage target roles (criteria, selected skills, **linked resume**) · **Resumes** | `data-model.md` Role + Resume |
+| **Job Preferences** | Locations · Work Models · Job Types | `data-model.md` JobPreferences (global) |
+| **Admin** | Stats · Job Sources · LLM & Models · System | operational surfaces |
+
+Key IA moves baked into the target (per §0 of the data model):
+- **Skills** is a destination *inside Candidate Profile* (skills belong to the person, defined once).
+- **Resumes** folds *under Roles* (each role links its matching resume).
+- **Job Preferences** is a *new* top-level destination for the global locations / work-model /
+  job-type settings (these are search-wide, never per-role).
+
+### 3.3 User footer
+
+A `.me` row at the rail bottom — avatar, name, settings cog.
+
+---
+
+## 4. The main region — shared chrome
+
+Two stacked bars sit above the active view:
+
+### 4.1 Context bar (`#ctx`) — **view-aware**
+
+The header changes by view (driven by a `VIEW_HEAD` map). It has two modes:
+
+- **Feed mode** — active target dot + name, its criteria chips, the live match count, and a
+  live-ingest indicator.
+- **Management mode** — for Profile / Roles / Resumes / Job Preferences / Admin views: a
+  view-specific title + icon + one-line descriptor. **No job-filter content** (no criteria chips,
+  no match count) — those are meaningless off the feed.
+
+> This was an explicit user requirement: *"when the user is managing Profiles/Resumes the top bar
+> will need to change. It should not always show the Job filter information."*
+
+### 4.2 Subbar (`#subbar`) — **feed-only filters**
+
+Visible only on feed views; hidden on all management views. Holds:
+- a **completeness filter** segment — **All · Full jobs · Snippets**,
+- a search box.
+
+(**Snippets** = postings discovered but not yet LLM-scored. They render in a distinct pre-scrape
+state: muted dashed flag, `—` score, "awaiting scrape" badge, a ⟳ Scrape action.)
+
+---
+
+## 5. The screens (views)
+
+Each view is a full panel in the main region. The feed is the default.
+
+### 5.1 Feed (default)
+The dense job list. Each row: score (tier-colored) · left tier flag · title (serif) · company /
+location / salary metadata (mono) · matched/missing skill chips · badges (new/remote/source) ·
+quick actions (View · ★ · ✓ · ×). In Combined view, rows also carry per-target color pills.
+**New (per data model A.10):** each row shows a **salary delta vs the candidate's base salary**
+("+20% vs base"); a posting with no extracted salary shows a **red "no salary" flag**, not a drop.
+Clicking a row opens the inspector (§6).
+
+### 5.2 Candidate Profile  *(target IA)*
+The person, one source of truth: identity (name, email, **current location**, **current role**),
+education, **base salary**, and the **Skills** shared-bucket manager. Skills here are the global
+`{id, name, years}` definitions; roles only *reference* them — editing a skill here never edits a role.
+
+### 5.3 Roles  *(master–detail editor)*
+The headline new feature. Left = compact role list (dot · name · skill count · match count, paused
+roles flagged, **+ New target role**). Right = a single role editor organized into **three labeled
+bands** that make the data-model tiers visible:
+
+1. **Target-defined** (Tier 1) — search query, prefilter title include/exclude, score threshold,
+   scoring notes.
+2. **Shared, overridable** (Tier 2) — seniority, preferred industries: each shows the inherited
+   candidate default *inline* with an "override for this role" toggle + "revert to shared."
+3. **Skills applicable** — the shared bucket shown as chips; a check toggles whether each shared
+   skill applies to this role (binary — no per-role weighting). **+ target salary** (seeded from
+   base salary, editable) and the **linked default resume** live here.
+
+**Resumes** (the per-role resume library) is reached under this destination.
+
+### 5.4 Job Preferences  *(target IA — global)*
+The search-wide settings that apply to every role equally and cannot be overridden:
+**Locations** (multiple willing-to-work places, one global radius), **Work Models** (onsite /
+hybrid / remote multi-select), **Job Types** (Contract / Contract-to-Hire / Full-Time / … ). These
+are **hard pull filters** — they exclude postings at ingestion.
+
+### 5.5 Admin
+Four operational views:
+- **Stats** — pipeline KPIs (ingested / scored / high-match / applied / apply-rate / avg-score) +
+  per-target matches table.
+- **Job Sources** — provider list (LinkedIn, Indeed, Greenhouse, Lever, HN, Wellfound) with
+  drag-priority, last-run/volume/dupe columns, status pills, per-source enable toggle. Hosts the
+  **Ingest activity log** (searchable table — §6).
+- **LLM & Models** — per-stage model routing (scoring / extraction / dedup / resume-tailoring) +
+  provider keys + token budget.
+- **System** — schedule & storage, maintenance actions, a red-bordered danger zone.
+
+---
+
+## 6. Cross-cutting surfaces
+
+### 6.1 Right inspector
+Slides in from the right (grid column 0 → 360px) when a job row is clicked. Holds the job's score
+breakdown, matched/gap skills, verdict, and the **resume tie-in** (pick a per-application resume →
+"Attach & apply"). `Esc` or ✕ closes it. This is the designed density-expansion point for richer
+detail (full description, application timeline) later.
+
+### 6.2 Ingest log — two distinct surfaces (hybrid, by design)
+The user explicitly split this into two forms:
+
+- **User-facing live stream** — a small **Ingest FAB** in the bottom-right of feed/role views opens
+  a **horizontal bar that slides up from the bottom**: a LIVE indicator, the source currently being
+  scraped, a running count, and a left-scrolling stream of target-colored event chips. Also openable
+  from the top-bar ingest indicator. Feed/role views only; auto-closes when navigating away.
+- **Admin-facing analytics** — an **Ingest activity log** table under Admin → Job Sources:
+  time · source · target · event · detail, with a search box and an event-type filter
+  (All · Discovered · Scored · Deduped · Errors).
+
+Both share one event vocabulary so the live chips and the log rows read identically.
+
+---
+
+## 7. Layout & responsive rules (summary — full rules in `design-principles.md`)
+
+- **Alignment by width:** expanding-width elements (fluid grids, tables, `1fr` form columns,
+  `auto-fill` tiles, the feed) are **left-aligned and fill** — no `max-width` cap. Fixed-width
+  elements (a bounded card/modal/control) are **center-aligned**. The intent is to eliminate the
+  dead band of wasted space on the right. Exceptions: prose reading-measures (`~60ch`) stay capped;
+  inline fixed controls inside a left-aligned form stay put.
+- **Responsive:** the rail collapses to icons at `980px`; the Roles editor's two-pane layout
+  collapses at `860px`.
+- **State persistence:** the active target persists to `localStorage` (`jm_target`).
+- **`data-od-id`** on every major region (`shell`, `rail`, `main`, `context`, `filters`, `feed`,
+  `inspector`, `ingest-fab`, `ingest-stream`, `ingest-log`, the per-view ids) so regions are
+  individually addressable.
+
+---
+
+## 8. What's locked vs. open
+
+**Locked:** the Shell B three-region layout; the dark ledger visual system; the view-aware context
+bar; the feed-only subbar; the inspector pattern; the hybrid ingest log; the Roles master–detail
+editor with three tier bands; the alignment rule.
+
+**Open / pending build:**
+- The rail's **three-top-level-destination IA** (Candidate Profile · Roles · Job Preferences) is
+  the target but **not yet reflected** in the prototype rail (§3.2 callout). The build toward it
+  also needs the **Job Preferences** screen and the **Candidate Profile / Skills** screen, which do
+  not exist as standalone surfaces yet.
+- The Roles editor still needs to be rebuilt against the real schema (see `roles-editor-rebuild.md`)
+  — current prototype invents skill tiers and misses several real fields.
+- Salary delta-vs-base on feed rows (A.10) and the no-salary red flag are designed but not built.
+
+---
+
+*Companion docs: `data-model.md` (entities/fields/relations — normative), `roles-editor-rebuild.md`
+(Roles editor build plan), `design-principles.md` (alignment/visual rules). Keep this file in sync
+when the rail IA or any screen's region structure changes.*


### PR DESCRIPTION
## Summary

Vendors the five **OpenDesign 2.0 handoff documents** into `docs/design/` so they become a durable, in-repo **UI fidelity anchor** for the 2.0 UI work (Cycle 2, #749). The 2.0 architecture ADR cites `ui-layout.md` and `api-surface.md §6` as the authoritative UI/API source, but those files previously lived **only in the external Open Design app project folder** — making "does the UI match the Designer?" unverifiable. This resolves open spec item **O4**.

## Files added (verbatim)

| File | Role |
|---|---|
| `docs/design/ui-layout.md` | Shell-B layout — UI authority |
| `docs/design/api-surface.md` | Resource API surface (+ §6 open decisions) |
| `docs/design/data-model.md` | Canonical entity/field model |
| `docs/design/design-principles.md` | Alignment / visual rules |
| `docs/design/roles-editor-rebuild.md` | Roles editor rebuild notes |

## Provenance

- **Source:** Open Design project `0115656f-3dfa-45ce-a2d7-e6857d2f2f6a`, captured **2026-05-29**.
- **Conflict rule:** where these handoff docs disagree with the locked entity model, **the locked model wins** (e.g. `scoring_notes` / `anti_preferences` are Profile **baseline + per-Role additions** in the locked specs, vs role-only in the handoff). These are vendored as the *design reference of record*, **not** as a spec that overrides the ADRs. The known design↔model deltas are exactly what Cycle 2 (#749) Slice 0 reconciles.
- Docs are committed **verbatim** (no edits); they retain their original internal cross-references and absolute-path citations.

## Notes

- Docs-only change — no code, no CI behavior impact.
- `docs/design/2026-05-30-deploy-secrets-decision.md` is pre-existing and untouched.

Closes #764

> 🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_